### PR TITLE
Feature/export deck

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/next/coverage

--- a/next/components/deck-export.js
+++ b/next/components/deck-export.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { copyToClipboard } from '../lib/copy-to-clipboard';
 
 class DeckExport extends React.Component {
   constructor(props) {
@@ -17,13 +18,8 @@ class DeckExport extends React.Component {
       return;
     }
 
-    if (!navigator || !navigator.clipboard || !navigator.clipboard.writeText) {
-      this.setState({ message: 'Export not supported in this browser' });
-      return;
-    }
-
-    navigator.clipboard.writeText(textToExport);
-    this.setState({ message: 'Copied' });
+    const success = copyToClipboard(textToExport);
+    this.setState({ message: success ? 'Copied' : 'Failed to copy' });
 
     // Make message disappear
     window.setTimeout(() => {

--- a/next/components/deck-export.js
+++ b/next/components/deck-export.js
@@ -1,0 +1,53 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+class DeckExport extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { message: null };
+
+    this.handleExport = this.handleExport.bind(this);
+  }
+
+  handleExport() {
+    const { textToExport } = this.props;
+
+    if (!textToExport.trim()) {
+      this.setState({ message: 'No imported deck to export' });
+      return;
+    }
+
+    if (!navigator || !navigator.clipboard || !navigator.clipboard.writeText) {
+      this.setState({ message: 'Export not supported in this browser' });
+      return;
+    }
+
+    navigator.clipboard.writeText(textToExport);
+    this.setState({ message: 'Copied' });
+
+    // Make message disappear
+    window.setTimeout(() => {
+      this.setState({
+        message: null
+      });
+    }, 2000);
+  }
+
+  render() {
+    const { message } = this.state;
+
+    return (
+      <React.Fragment>
+        <button onClick={this.handleExport}>Export</button>
+        &nbsp;
+        {message && <span>{message}</span>}
+      </React.Fragment>
+    );
+  }
+}
+
+DeckExport.propTypes = {
+  textToExport: PropTypes.string
+};
+
+export default DeckExport;

--- a/next/components/deck.js
+++ b/next/components/deck.js
@@ -3,6 +3,7 @@ import gql from 'graphql-tag';
 import { Query } from 'react-apollo';
 import ErrorMessage from './error-message';
 import CardList from './card-list';
+import DeckExport from './deck-export';
 
 export const deckCardsQuery = gql`
   query($id: Int!) {
@@ -21,6 +22,17 @@ export const deckCardsQuery = gql`
   }
 `;
 
+const deckToExportText = cards => {
+  const cardsText = cards.map(card => `1 ${card.name}`.toLowerCase());
+  const metaLines = [
+    'name: PLACEHOLDER NAME',
+    "path: rainbow's end",
+    'power: reanimate'
+  ];
+
+  return metaLines.concat(cardsText).join('\n');
+};
+
 export default function Deck({ deck }) {
   return (
     <Query query={deckCardsQuery} variables={{ id: deck.id }}>
@@ -28,10 +40,14 @@ export default function Deck({ deck }) {
         if (error) return <ErrorMessage message="Error loading decks." />;
         if (loading) return <div>Loading</div>;
 
+        const cards = deck.cardDecks.nodes.map(({ card }) => card);
+        const asText = deckToExportText(cards);
+
         return (
           <>
             <h1 className="deckName">{deck.name}</h1>
-            <CardList cards={deck.cardDecks.nodes.map(({ card }) => card)} />
+            <CardList cards={cards} />
+            <DeckExport textToExport={asText} />
           </>
         );
       }}

--- a/next/components/imported-deck.js
+++ b/next/components/imported-deck.js
@@ -47,6 +47,7 @@ export default function ImportedDeck({ importedDeck }) {
     </div>
   );
 }
+
 ImportedDeck.propTypes = {
   importedDeck: PropTypes.shape({
     deckName: PropTypes.string,
@@ -66,6 +67,7 @@ ImportedDeck.propTypes = {
         name: PropTypes.string
       })
     ),
+    asText: PropTypes.string,
     errors: PropTypes.arrayOf(PropTypes.string)
   })
 };

--- a/next/lib/copy-to-clipboard.js
+++ b/next/lib/copy-to-clipboard.js
@@ -1,0 +1,44 @@
+const isOS = () => {
+  return (
+    navigator &&
+    navigator.userAgent &&
+    navigator.userAgent.match &&
+    navigator.userAgent.match(/ipad|iphone/i)
+  );
+};
+
+const selectText = textArea => {
+  if (isOS()) {
+    const range = document.createRange();
+    range.selectNodeContents(textArea);
+
+    const selection = window.getSelection();
+    selection.removeAllRanges();
+    selection.addRange(range);
+    textArea.setSelectionRange(0, 999999);
+  } else {
+    textArea.select();
+  }
+};
+
+export const copyToClipboard = text => {
+  if (!document || !window || !navigator) {
+    return false;
+  }
+
+  const textArea = document.createElement('textArea');
+  textArea.value = text;
+  textArea.readOnly = true;
+  document.body.appendChild(textArea);
+
+  selectText(textArea);
+
+  try {
+    document.execCommand('copy');
+    document.body.removeChild(textArea);
+    return true;
+  } catch (e) {
+    console.log(e);
+    return false;
+  }
+};

--- a/next/pages/deckbuilder.js
+++ b/next/pages/deckbuilder.js
@@ -66,7 +66,7 @@ class DeckbuilderPage extends React.Component {
   }
 
   render() {
-    const { importedDeck, mainDeckInput, sideboardInput, copied } = this.state;
+    const { importedDeck, mainDeckInput, sideboardInput } = this.state;
 
     return (
       <Layout title="Mythgard Hub | Decks" desc="Browse Mythgard decks">

--- a/next/pages/deckbuilder.js
+++ b/next/pages/deckbuilder.js
@@ -50,7 +50,6 @@ class DeckbuilderPage extends React.Component {
     this.state = {
       mainDeckInput: '',
       sideboardInput: '',
-      copied: false,
       importedDeck: initializeImportedDeck()
     };
 

--- a/next/pages/deckbuilder.js
+++ b/next/pages/deckbuilder.js
@@ -8,6 +8,7 @@ import {
   extractMetaValue
 } from '../lib/import-utils';
 import { handleInputChange } from '../lib/form-utils';
+import DeckExport from '../components/deck-export';
 
 const initializeImportedDeck = () => {
   return {
@@ -16,7 +17,8 @@ const initializeImportedDeck = () => {
     deckPower: '',
     mainDeck: [],
     sideboard: [],
-    errors: []
+    errors: [],
+    asText: ''
   };
 };
 
@@ -37,6 +39,7 @@ const convertImportToDeck = (mainDeckText, sideboardText) => {
   importedDeck.deckPower = extractMetaValue(mainDeckLines[2]);
   importedDeck.mainDeck = formatCardLines(mainDeckLines.slice(3));
   importedDeck.sideboard = formatCardLines(sideboardLines);
+  importedDeck.asText = mainDeckText;
 
   return importedDeck;
 };
@@ -47,6 +50,7 @@ class DeckbuilderPage extends React.Component {
     this.state = {
       mainDeckInput: '',
       sideboardInput: '',
+      copied: false,
       importedDeck: initializeImportedDeck()
     };
 
@@ -62,7 +66,7 @@ class DeckbuilderPage extends React.Component {
   }
 
   render() {
-    const { importedDeck, mainDeckInput, sideboardInput } = this.state;
+    const { importedDeck, mainDeckInput, sideboardInput, copied } = this.state;
 
     return (
       <Layout title="Mythgard Hub | Decks" desc="Browse Mythgard decks">
@@ -87,6 +91,8 @@ class DeckbuilderPage extends React.Component {
         <br />
         <br />
         <button onClick={this.handleImport}>Import</button>
+        &nbsp;
+        <DeckExport textToExport={importedDeck.asText} />
         <ImportedDeck importedDeck={importedDeck} />
         <h2>All Cards</h2>
         <AllCards />


### PR DESCRIPTION
Builds off this PR: https://github.com/mythgard-hub/mythgard-hub/pull/6

- added export functionality
- in the deckbuilder page, people can export a deck once they're imported it successfully. It doesn't do the sideboard because is there even a sideboard in this game? I didn't notice it

![image](https://user-images.githubusercontent.com/4063797/62014162-a5a23980-b16b-11e9-8202-9c7a5c2c9ef8.png)

- in the deck page, people can export the deck but it will add a temporary name, path and power. it will also add a default quantity of 1 to each card. we'll need to change the format of the deck page to have the user be able to change those things

![image](https://user-images.githubusercontent.com/4063797/62014188-e306c700-b16b-11e9-8182-dedaf2ca62df.png)
