### PR TITLE
Add cover art to deck import + loosen the rules of input to match the game more

### DIFF
--- a/next/constants/deck.js
+++ b/next/constants/deck.js
@@ -1,5 +1,6 @@
 export const META_KEYS = {
   NAME: 'name',
   PATH: 'path',
-  POWER: 'power'
+  POWER: 'power',
+  COVER_ART: 'coverart'
 };

--- a/next/lib/deck-utils.js
+++ b/next/lib/deck-utils.js
@@ -3,10 +3,9 @@ export const initializeDeckBuilder = () => {
     deckName: '',
     deckPath: '',
     deckPower: '',
-    deckCoverart: '',
+    deckCoverArt: '',
     mainDeck: [],
     sideboard: [],
-    errors: [],
-    asText: ''
+    errors: []
   };
 };

--- a/next/lib/import-utils.js
+++ b/next/lib/import-utils.js
@@ -1,15 +1,48 @@
 import { META_KEYS } from '../constants/deck';
 import { initializeDeckBuilder } from './deck-utils';
 
-export const extractMetaValue = line => {
+const hasCoverArt = line => {
+  return line.startsWith(`${META_KEYS.COVER_ART}:`);
+};
+
+// Get the line number where the meta information ends
+export const getSpliceIndex = lines => {
+  let index = 0;
+
+  while (index < lines.length) {
+    const currSplit = lines[index].split(':');
+
+    if (currSplit.length === 1) {
+      return index;
+    }
+
+    index++;
+  }
+
+  return index;
+};
+
+// Try to find a meta value. There could be 0-4 meta values
+export const extractMetaValue = (lines, metaname) => {
+  if (!Array.isArray(lines)) {
+    return null;
+  }
+
   try {
-    return line
-      .split(':')
-      .slice(1)
-      .join(':')
-      .trim();
+    let index = 0;
+
+    while (index < lines.length) {
+      const currSplit = lines[index].split(':');
+
+      if (currSplit[0] === metaname && currSplit[1]) {
+        return currSplit[1].trim();
+      }
+
+      index++;
+    }
+
+    return '';
   } catch (e) {
-    console.log(e);
     return null;
   }
 };
@@ -36,7 +69,6 @@ export const formatCardLines = cardLines => {
           name: split.slice(1).join(' ')
         };
       } catch (e) {
-        console.log(e);
         return line;
       }
     });
@@ -45,18 +77,19 @@ export const formatCardLines = cardLines => {
 };
 
 export const metaLineInvalid = (line, metaName) => {
+  // Gotta have the basics
+  if (!metaName || !line || !line.split) {
+    return true;
+  }
+
   const split = line && line.split && line.split(':');
 
-  return Boolean(
-    !metaName ||
-      !line ||
-      !split ||
-      !split.length ||
-      split.length < 2 ||
-      !line[0] ||
-      !line[0] === metaName ||
-      !line[1]
-  );
+  // The first element of the line has to be the meta name
+  if (!split || !split.length || split[0] !== metaName || split[0] === line) {
+    return true;
+  }
+
+  return false;
 };
 
 export const cardLinesValid = lines => {
@@ -67,45 +100,40 @@ export const cardLinesValid = lines => {
 };
 
 export const getImportErrors = (mainDeckText, sideboardText) => {
-  const errors = [];
+  try {
+    const errors = [];
 
-  const mainDeckLines = mainDeckText.split(/\n/);
-  const sideboardLines = formatCardLines(sideboardText.split(/\n/));
+    const mainDeckLines = mainDeckText.split(/\n/);
+    const sideboardLines = formatCardLines(sideboardText.split(/\n/));
 
-  // If we don't even have the first 3 lines, go home
-  if (mainDeckLines.length < 4) {
-    errors.push('Deck must have name, path, power and cards');
+    // We need at least a card
+    if (mainDeckLines.length < 1) {
+      errors.push('Deck must have some cards');
+      return errors;
+    }
+
+    // the export can have a bunch of meta lines.
+    // We need to figre out where to start splicing to get the actual cards
+    const spliceIndex = getSpliceIndex(mainDeckLines);
+    const cardLines = formatCardLines(mainDeckLines.splice(spliceIndex));
+
+    if (cardLines.length <= 0) {
+      errors.push('Deck must have cards');
+    }
+
+    if (!cardLinesValid(cardLines)) {
+      errors.push('Invalid input for main deck');
+    }
+
+    // If sideboard is not empty, it's gotta have good lines too
+    if (!cardLinesValid(sideboardLines)) {
+      errors.push('Invalid input for sideboard');
+    }
+
     return errors;
+  } catch (e) {
+    return ['Invalid input for main deck'];
   }
-
-  if (metaLineInvalid(mainDeckLines[0], META_KEYS.NAME)) {
-    errors.push('Deck must have a name');
-  }
-
-  if (metaLineInvalid(mainDeckLines[1], META_KEYS.PATH)) {
-    errors.push('Deck must have an entry for path (it can be empty)');
-  }
-
-  if (metaLineInvalid(mainDeckLines[2], META_KEYS.POWER)) {
-    errors.push('Deck must have an entry for power (it can be empty)');
-  }
-
-  const cardLines = formatCardLines(mainDeckLines.splice(3));
-
-  if (cardLines.length <= 0) {
-    errors.push('Deck must have cards');
-  }
-
-  if (!cardLinesValid(cardLines)) {
-    errors.push('Invalid input for main deck');
-  }
-
-  // If sideboard is not empty, it's gotta have good lines too
-  if (!cardLinesValid(sideboardLines)) {
-    errors.push('Invalid input for sideboard');
-  }
-
-  return errors;
 };
 
 export const convertImportToDeck = (mainDeckText, sideboardText) => {
@@ -119,13 +147,18 @@ export const convertImportToDeck = (mainDeckText, sideboardText) => {
 
   const mainDeckLines = mainDeckText.split(/\n/g);
   const sideboardLines = sideboardText.split(/\n/g);
+  const spliceIndex = getSpliceIndex(mainDeckLines);
 
-  importedDeck.deckName = extractMetaValue(mainDeckLines[0]);
-  importedDeck.deckPath = extractMetaValue(mainDeckLines[1]);
-  importedDeck.deckPower = extractMetaValue(mainDeckLines[2]);
-  importedDeck.mainDeck = formatCardLines(mainDeckLines.slice(3));
+  importedDeck.mainDeck = formatCardLines(mainDeckLines.slice(spliceIndex));
   importedDeck.sideboard = formatCardLines(sideboardLines);
-  importedDeck.asText = mainDeckText;
+
+  importedDeck.deckName = extractMetaValue(mainDeckLines, META_KEYS.NAME);
+  importedDeck.deckPath = extractMetaValue(mainDeckLines, META_KEYS.PATH);
+  importedDeck.deckPower = extractMetaValue(mainDeckLines, META_KEYS.POWER);
+  importedDeck.deckCoverArt = extractMetaValue(
+    mainDeckLines,
+    META_KEYS.COVER_ART
+  );
 
   return importedDeck;
 };

--- a/next/lib/import-utils.js
+++ b/next/lib/import-utils.js
@@ -1,10 +1,6 @@
 import { META_KEYS } from '../constants/deck';
 import { initializeDeckBuilder } from './deck-utils';
 
-const hasCoverArt = line => {
-  return line.startsWith(`${META_KEYS.COVER_ART}:`);
-};
-
 // Get the line number where the meta information ends
 export const getSpliceIndex = lines => {
   let index = 0;

--- a/next/lib/import-utils.js
+++ b/next/lib/import-utils.js
@@ -6,9 +6,7 @@ export const getSpliceIndex = lines => {
   let index = 0;
 
   while (index < lines.length) {
-    const currSplit = lines[index].split(':');
-
-    if (currSplit.length === 1) {
+    if (lines[index].indexOf(':') === -1) {
       return index;
     }
 
@@ -78,14 +76,10 @@ export const metaLineInvalid = (line, metaName) => {
     return true;
   }
 
-  const split = line && line.split && line.split(':');
+  const split = line.split(':');
 
   // The first element of the line has to be the meta name
-  if (!split || !split.length || split[0] !== metaName || split[0] === line) {
-    return true;
-  }
-
-  return false;
+  return !split || !split.length || split[0] !== metaName || split[0] === line;
 };
 
 export const cardLinesValid = lines => {


### PR DESCRIPTION
Trello: https://trello.com/c/M4rOTeVM/51-deckbuilder-hide-sideboard-and-add-coverart-to-import-export

- Cover art was added to the constants and default deck in progress
- The import was changed so that it accepts any number of meta values - looks like the game is more flexible and doesn't actually require a name, path, power or anything
- Tests were changed to reflect that part

TODO

- export will be fixed in another PR
- e2e tests will be added in another PR