### PR TITLE
Card quantities

### DIFF
--- a/e2e/cypress/integration/deck-page.js
+++ b/e2e/cypress/integration/deck-page.js
@@ -4,8 +4,8 @@ describe('Deck Page', function() {
   });
   it('happy path card click', function() {
     cy.get('h1').should('have.class', 'deckName');
-    cy.get('.cardList').should('have.length', 1);
-    cy.get('.cardList a:first').click();
+    cy.get('[data-cy=deckCardList]').should('have.length', 1);
+    cy.get('[data-cy=deckCardList] a:first').click();
     cy.location().should(location => {
       expect(location.pathname).to.contain('/card');
     });

--- a/next/components/card-list-item.js
+++ b/next/components/card-list-item.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import Link from 'next/link';
+import PropTypes from 'prop-types';
+
+export default function CardListItem({ card, onCardClick }) {
+  return (
+    <Link href={`/card?id=${card.id}`}>
+      <a data-cy="cardListCard" onClick={e => onCardClick(e, card)}>
+        {card.id}. name: {card.name}
+      </a>
+    </Link>
+  );
+}
+
+CardListItem.propTypes = {
+  card: PropTypes.shape({
+    id: PropTypes.number.isRequired,
+    name: PropTypes.string.isRequired
+  }).isRequired,
+  onCardClick: PropTypes.func
+};
+
+CardListItem.defaultProps = {
+  onCardClick: () => {}
+};

--- a/next/components/card-list-item.js
+++ b/next/components/card-list-item.js
@@ -2,10 +2,10 @@ import React from 'react';
 import Link from 'next/link';
 import PropTypes from 'prop-types';
 
-export default function CardListItem({ card, onCardClick }) {
+export default function CardListItem({ card, onClick }) {
   return (
     <Link href={`/card?id=${card.id}`}>
-      <a data-cy="cardListCard" onClick={e => onCardClick(e, card)}>
+      <a data-cy="cardListCard" onClick={e => onClick(e, card)}>
         {card.id}. name: {card.name}
       </a>
     </Link>
@@ -17,9 +17,9 @@ CardListItem.propTypes = {
     id: PropTypes.number.isRequired,
     name: PropTypes.string.isRequired
   }).isRequired,
-  onCardClick: PropTypes.func
+  onClick: PropTypes.func
 };
 
 CardListItem.defaultProps = {
-  onCardClick: () => {}
+  onClick: () => {}
 };

--- a/next/components/card-list.js
+++ b/next/components/card-list.js
@@ -1,17 +1,12 @@
-import Link from 'next/link';
 import PropTypes from 'prop-types';
+import CardListItem from './card-list-item';
 
 export default function CardList({ onCardClick, cards }) {
   return (
     <ul className="cardList" data-cy="cardList">
       {cards.map((card, index) => (
         <li key={card.id ? card.id : index}>
-          {card.quantity && <span>{card.quantity}</span>}&nbsp;
-          <Link href={`/card?id=${card.id}`} key={index}>
-            <a data-cy="cardListCard" onClick={e => onCardClick(e, card)}>
-              {card.id}. name: {card.name}
-            </a>
-          </Link>
+          <CardListItem card={card} onClick={onCardClick} />
         </li>
       ))}
     </ul>

--- a/next/components/deck-card-list.js
+++ b/next/components/deck-card-list.js
@@ -1,21 +1,27 @@
-import Link from 'next/link';
 import PropTypes from 'prop-types';
+import CardListItem from './card-list-item';
 
-export default function DeckCardList({ cards }) {
+export default function DeckCardList({ deckCards }) {
   return (
     <ul className="deckCardList" data-cy="deckCardList">
-      {cards.map((card, index) => (
+      {deckCards.map((deckCard, index) => (
         <li key={index}>
-          <Link href={`/card?id=${card.id}`} key={index}>
-            <a data-cy="deckCardListCard">
-              {card.id}. name: {card.name}
-            </a>
-          </Link>
+          <CardListItem card={deckCard.card} />
+          <span> X {deckCard.quantity}</span>
         </li>
       ))}
     </ul>
   );
 }
+
 DeckCardList.propTypes = {
-  cards: PropTypes.array
+  deckCards: PropTypes.arrayOf(
+    PropTypes.shape({
+      quantity: PropTypes.number.isRequired,
+      card: PropTypes.shape({
+        id: PropTypes.number.isRequired,
+        name: PropTypes.string.isRequired
+      }).isRequired
+    })
+  ).isRequired
 };

--- a/next/components/deck.js
+++ b/next/components/deck.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import gql from 'graphql-tag';
 import { Query } from 'react-apollo';
 import ErrorMessage from './error-message';
+import DeckCardList from './deck-card-list';
 import CardList from './card-list';
 import DeckExport from './deck-export';
 
@@ -12,6 +13,7 @@ export const deckCardsQuery = gql`
       name
       cardDecks {
         nodes {
+          quantity
           card {
             name
             id
@@ -22,8 +24,10 @@ export const deckCardsQuery = gql`
   }
 `;
 
-const deckToExportText = cards => {
-  const cardsText = cards.map(card => `1 ${card.name}`.toLowerCase());
+const deckToExportText = deckCards => {
+  const cardsText = deckCards.map(deckCard =>
+    `${deckCard.quantity} ${deckCard.card.name}`.toLowerCase()
+  );
   const metaLines = [
     'name: PLACEHOLDER NAME',
     "path: rainbow's end",
@@ -40,13 +44,13 @@ export default function Deck({ deck }) {
         if (error) return <ErrorMessage message="Error loading decks." />;
         if (loading) return <div>Loading</div>;
 
-        const cards = deck.cardDecks.nodes.map(({ card }) => card);
+        const cards = deck.cardDecks.nodes;
         const asText = deckToExportText(cards);
 
         return (
           <>
             <h1 className="deckName">{deck.name}</h1>
-            <CardList cards={cards} />
+            <DeckCardList deckCards={cards} />
             <DeckExport textToExport={asText} />
           </>
         );

--- a/next/lib/deck-utils.js
+++ b/next/lib/deck-utils.js
@@ -3,7 +3,7 @@ export const initializeDeckBuilder = () => {
     deckName: '',
     deckPath: '',
     deckPower: '',
-    deckCoverart: '',
+    deckCoverArt: '',
     mainDeck: {},
     sideboard: [],
     errors: []

--- a/next/lib/deck-utils.js
+++ b/next/lib/deck-utils.js
@@ -4,7 +4,7 @@ export const initializeDeckBuilder = () => {
     deckPath: '',
     deckPower: '',
     deckCoverart: '',
-    mainDeck: [],
+    mainDeck: {},
     sideboard: [],
     errors: [],
     asText: ''

--- a/next/lib/import-utils.js
+++ b/next/lib/import-utils.js
@@ -123,7 +123,20 @@ export const convertImportToDeck = (mainDeckText, sideboardText) => {
   importedDeck.deckName = extractMetaValue(mainDeckLines[0]);
   importedDeck.deckPath = extractMetaValue(mainDeckLines[1]);
   importedDeck.deckPower = extractMetaValue(mainDeckLines[2]);
-  importedDeck.mainDeck = formatCardLines(mainDeckLines.slice(3));
+  importedDeck.mainDeck = formatCardLines(mainDeckLines.slice(3)).reduce(
+    (acc, curr, ix) => {
+      // TODO These need to get actual ID values from the card list
+      acc[`${curr.id}_${ix}`] = {
+        quantity: curr.quantity,
+        card: {
+          id: curr.id,
+          name: curr.name
+        }
+      };
+      return acc;
+    },
+    {}
+  );
   importedDeck.sideboard = formatCardLines(sideboardLines);
   importedDeck.asText = mainDeckText;
 

--- a/next/lib/import-utils.js
+++ b/next/lib/import-utils.js
@@ -139,7 +139,19 @@ export const convertImportToDeck = (mainDeckText, sideboardText) => {
   const sideboardLines = sideboardText.split(/\n/g);
   const spliceIndex = getSpliceIndex(mainDeckLines);
 
-
+  importedDeck.mainDeck = formatCardLines(
+    mainDeckLines.slice(spliceIndex)
+  ).reduce((acc, curr, ix) => {
+    // TODO These need to get actual ID values from the card list
+    acc[`${curr.id}_${ix}`] = {
+      quantity: curr.quantity,
+      card: {
+        id: curr.id,
+        name: curr.name
+      }
+    };
+    return acc;
+  }, {});
   importedDeck.sideboard = formatCardLines(sideboardLines);
 
   importedDeck.deckName = extractMetaValue(mainDeckLines, META_KEYS.NAME);

--- a/next/lib/import-utils.test.js
+++ b/next/lib/import-utils.test.js
@@ -313,7 +313,7 @@ describe('Import utility methods', () => {
       expect(result.deckName).toEqual('my deck');
       expect(result.deckPath).toEqual('my path');
       expect(result.deckPower).toEqual('my power');
-      expect(result.mainDeck.length).toEqual(1);
+      expect(Object.values(result.mainDeck).length).toEqual(1);
     });
 
     it('Should convert an import to a deck in progress - multiple cards', function() {
@@ -334,7 +334,7 @@ describe('Import utility methods', () => {
       expect(result.deckName).toEqual('my deck');
       expect(result.deckPath).toEqual('my path');
       expect(result.deckPower).toEqual('my power');
-      expect(result.mainDeck.length).toEqual(3);
+      expect(Object.values(result.mainDeck).length).toEqual(3);
     });
 
     it('Should convert an import to a deck in progress - partial meta information', function() {
@@ -354,7 +354,7 @@ describe('Import utility methods', () => {
       expect(result.deckName).toEqual('my deck');
       expect(result.deckPath).toEqual('');
       expect(result.deckPower).toEqual('my power');
-      expect(result.mainDeck.length).toEqual(3);
+      expect(Object.values(result.mainDeck).length).toEqual(3);
     });
 
     it('Should convert an import to a deck in progress - no meta information', function() {
@@ -371,7 +371,7 @@ describe('Import utility methods', () => {
       expect(result.deckName).toEqual('');
       expect(result.deckPath).toEqual('');
       expect(result.deckPower).toEqual('');
-      expect(result.mainDeck.length).toEqual(3);
+      expect(Object.values(result.mainDeck).length).toEqual(3);
     });
 
     it('Should convert an import to a deck in progress - empty lines', function() {
@@ -394,7 +394,7 @@ describe('Import utility methods', () => {
       expect(result.deckName).toEqual('my deck');
       expect(result.deckPath).toEqual('my path');
       expect(result.deckPower).toEqual('my power');
-      expect(result.mainDeck.length).toEqual(3);
+      expect(Object.values(result.mainDeck).length).toEqual(3);
     });
 
     it('Should not do anything besides populate errors - invalid cards', function() {
@@ -413,7 +413,7 @@ describe('Import utility methods', () => {
       expect(result.deckName).toEqual('');
       expect(result.deckPath).toEqual('');
       expect(result.deckPower).toEqual('');
-      expect(result.mainDeck.length).toEqual(0);
+      expect(Object.values(result.mainDeck).length).toEqual(0);
     });
   });
 });

--- a/postgres/init.sql
+++ b/postgres/init.sql
@@ -29,7 +29,8 @@ CREATE TABLE mythgard.card_deck (
   FOREIGN KEY (deck_id)
     REFERENCES mythgard.deck (id),
   FOREIGN KEY (card_id)
-    REFERENCES mythgard.card (id)
+    REFERENCES mythgard.card (id),
+  UNIQUE(deck_id, card_id)
 );
 
 INSERT INTO mythgard.card_deck("deck_id", "card_id", "quantity") VALUES (1, 4, 2);

--- a/postgres/init.sql
+++ b/postgres/init.sql
@@ -23,6 +23,7 @@ INSERT INTO mythgard.deck("name") VALUES ('cats');
 
 CREATE TABLE mythgard.card_deck (
   id SERIAL PRIMARY KEY,
+  quantity integer,
   deck_id integer,
   card_id integer,
   FOREIGN KEY (deck_id)
@@ -31,8 +32,8 @@ CREATE TABLE mythgard.card_deck (
     REFERENCES mythgard.card (id)
 );
 
-INSERT INTO mythgard.card_deck("deck_id", "card_id") VALUES (1, 4);
-INSERT INTO mythgard.card_deck("deck_id", "card_id") VALUES (2, 1);
+INSERT INTO mythgard.card_deck("deck_id", "card_id", "quantity") VALUES (1, 4, 2);
+INSERT INTO mythgard.card_deck("deck_id", "card_id", "quantity") VALUES (2, 1, 1);
 
 -- Create the function named `search_decks` with a text argument named `title`.
 -- This will expose `Query.searchDecks(name: String!, ...)` to GraphQL.


### PR DESCRIPTION
I know we just went through the trouble of removing, but I ended up restoring `deck-card-list`. The data structure that each takes is slightly different (i.e. cardDeck vs. a plain ol' card), and beginning with quantity I expect that card list may diverge in appearance/behavior depending on whether they are displayed in the context of a deck or just as a plain list of cards. If you guys have thoughts otherwise I'm happy to make adjustments.

I think this will cause some conflicts with Lily's PR since I've modified the main card list to be an object for easier lookup; I can clean those up once that gets merged.

I've called out as a TODO some validation around imported cards, since in order to properly save them to the deck we will need to associate them with their IDs. I'll add this as a separate card since it seems like we have some options for how to approach this.