### PR TITLE
Make postgres/init.sql idempotent

### DIFF
--- a/postgres/init.sql
+++ b/postgres/init.sql
@@ -1,3 +1,5 @@
+DROP SCHEMA IF EXISTS mythgard CASCADE;
+
 CREATE SCHEMA mythgard;
 CREATE TABLE mythgard.card (
   id SERIAL PRIMARY KEY,

--- a/scripts/hotswap-db.sh
+++ b/scripts/hotswap-db.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+CONAINER_ID=$(docker ps -aqf "ancestor=mg-postgres")
+PGDATABASE=$(grep PGDATABASE .env | cut -d '=' -f 2-)
+PGUSER=$(grep PGUSER .env | cut -d '=' -f 2-)
+PGPASSWORD=$(grep PGPASSWORD .env | cut -d '=' -f 2-)
+echo "PGPASSWORD=$PGPASSWORD psql -U $PGUSER -d $PGDATABASE -a -f /docker-entrypoint-initdb.d/init.sql" | docker exec -i "$CONAINER_ID" /bin/bash


### PR DESCRIPTION
This also allows us to:

- Run the init script over and over without errors or different results.
- Easily get a clean DB slate without rebuilding the container.