### PR TITLE
Kubernetify

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -13,6 +13,7 @@ PGHOST=db
 PGPASSWORD=example
 PGDATABASE=postgres
 PGPORT=5432
+PGSSL=no
 
 # Configs For JWTs
 JWT_COOKIE_NAME=jwt
@@ -22,3 +23,6 @@ JWT_AUDIENCE=mythgardhub.com
 
 # A loop-back for SSR requests
 SSR_HOST=http://next:3001
+
+# Endpoint for talking to the express app internally
+API_HOST=http://express:3000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,9 +36,7 @@ services:
     env_file:
       - .env
     volumes:
-      - type: bind
-        source: ./next
-        target: /app
       - /app/node_modules
     ports:
       - "3001:3001"
+    command: ["npm", "run", "dev"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,9 @@ services:
     env_file:
       - .env
     volumes:
+      - type: bind
+        source: ./next
+        target: /app
       - /app/node_modules
     ports:
       - "3001:3001"

--- a/express/index.js
+++ b/express/index.js
@@ -13,7 +13,8 @@ app.use(
       user: process.env.PGUSER,
       database: process.env.PGDATABASE,
       password: process.env.PGPASSWORD,
-      host: process.env.PGHOST
+      host: process.env.PGHOST,
+      ssl: process.env.PGSSL === 'yes'
     },
     'mythgard',
     {

--- a/express/package.json
+++ b/express/package.json
@@ -1,7 +1,8 @@
 {
   "name": "mythgard-express",
   "version": "1.0.0",
-  "description": "",
+  "description": "The Mythard Hub back-end server",
+  "repository": "https://github.com/mythgard-hub/mythgard-hub",
   "main": "index.js",
   "scripts": {
     "test": "jest"

--- a/next/.dockerignore
+++ b/next/.dockerignore
@@ -1,5 +1,8 @@
-node_modules/*
-.eslintrc
-.prettierrc.yml
+.babelrc
+.dockerignore
+.eslintrc.json
 .gitignore
+.prettierrc.yml
+.next
 build.sh
+node_modules/*

--- a/next/Dockerfile
+++ b/next/Dockerfile
@@ -1,16 +1,8 @@
 FROM node:lts-alpine
 
 WORKDIR /app
+COPY . /app
 
-COPY package* ./
+RUN npm i --production --no-optional && npm run build
 
-RUN npm i --production
-
-COPY server.js .
-COPY pages .
-COPY components .
-COPY lib .
-COPY server-routes .
-COPY next.config.js .
-
-CMD ["npm", "run", "dev"]
+CMD ["npm", "start"]

--- a/next/components/init-apollo.js
+++ b/next/components/init-apollo.js
@@ -8,9 +8,9 @@ let apolloClient = null;
 // currently proxies requests for the graphql server.
 // This will need to be removed in production.
 // TODO https://trello.com/c/EwDfaRIo/28
-const serverUri = 'express:3000/graphql'; // docker-compose url
-const browserUri = 'localhost:3001/graphql'; // proxied through next
-const uri = `http://${process.browser ? browserUri : serverUri}`;
+const serverUri = `${process.env.API_HOST}/graphql`; // docker-compose url
+const browserUri = '/graphql'; // proxied through next
+const uri = process.browser ? browserUri : serverUri;
 
 const makeCache = initialState =>
   new InMemoryCache({

--- a/next/package.json
+++ b/next/package.json
@@ -1,7 +1,8 @@
 {
   "name": "nextjs",
   "version": "1.0.0",
-  "description": "",
+  "description": "The Mythard Hub front-end server",
+  "repository": "https://github.com/mythgard-hub/mythgard-hub",
   "main": "index.js",
   "scripts": {
     "dev": "node server.js",

--- a/next/server.js
+++ b/next/server.js
@@ -34,7 +34,7 @@ app
 
     server.use(
       '/graphql',
-      proxy('http://express:3000', {
+      proxy(process.env.API_HOST, {
         proxyReqPathResolver: () => {
           return `/graphql`;
         }


### PR DESCRIPTION
These changes enable the k8s deployment. Some things to note:

- There's a new `.env` variable, `PGSSL`, you can update your actual `.env.` file with the template value.
- There's a new `.env` variable, `API_HOST`, you can update your actual `.env.` file with the template value.
- The docker-compose file is no longer mounting `next/.next` as a volume. Was anyone making use of this? As a general rule we should avoid mounting resources that are purely derived from things already in the  container.
- Dockerfiles (for the `next` and `express` services in particular) should prep images for production rather than dev. Use docker-compose to make adjustments fo dev (k8s uses the Dockerfiles but not docker-compose files). If this gets to be annoying, we can have separate Dockerfiles for dev and prod envs. Right now, the only way this really impacts us is that the next service includes `npm run build` in its Dockerfile which amounts to just waiting for funsies if you're going to start the server in dev mode.
- Always use env variables to reference things like the server host names or ports.

There are separate k8s configs that are not included in this PR. I've still got to carve out secrets in those configs into [secrets](https://kubernetes.io/docs/concepts/configuration/secret/)... and I'm not even 100% sure those configs belong in this repo. In any event I'd like to get (and keep) this repo in k8s deployment shape.