### PR TITLE
Add Travis CI for automated test running

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ node_js:
 
 sudo: required
 
-# Cypress seems to think this is needed :shrug:
+# Supposedly this is needed for Cypress to work in Ubuntu 16
 # https://github.com/cypress-io/cypress-example-kitchensink/blob/master/basic/.travis.yml
 addons:
   apt:
@@ -44,7 +44,7 @@ script:
   - cd next
   - npm run test
   # Run e2e tests
-  - cd e2e
+  - cd ../e2e
   - npx cypress verify
   - npx cypress run -- --record
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: node_js
+node_js:
+  - "10"
 
 sudo: required
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,12 @@ before_install:
   - cp .env.template .env
 
 install:
+  - cd next
+  - npm install
+  - cd ..
+  - cd e2e
+  - npm install
+  - cd ..
   - docker-compose up --build -d
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ services:
 
 before_install:
   # Upgrade docker-compose to the desired version
-  - sudo rm /usr/local/bin/docker-compoose
+  - sudo rm /usr/local/bin/docker-compose
   - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
   - chmod +x docker-compose
   - sudo mv docker-compose /usr/local/bin

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ before_install:
   # Upgrade docker
   - sudo apt-get update
   - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
+  # Put the .env file in place
+  - cp .env.template .env
 
 install:
   - docker-compose up

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,9 +35,6 @@ install:
   - cd next
   - npm install
   - cd ..
-  - cd e2e
-  - npm install
-  - cd ..
   - docker-compose up --build -d
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_install:
   - cp .env.template .env
 
 install:
-  - docker-compose up
+  - docker-compose up --build -d
 
 script:
   # Run unit tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "10"
+  - "lts/*"
 
 sudo: required
 
@@ -31,6 +31,7 @@ before_install:
   - cp .env.template .env
 
 install:
+  # Install node modules and start up the docker containers
   - cd next
   - npm install
   - cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,13 @@ node_js:
 
 sudo: required
 
+# Cypress seems to think this is needed :shrug:
+# https://github.com/cypress-io/cypress-example-kitchensink/blob/master/basic/.travis.yml
+addons:
+  apt:
+    packages:
+      - libgconf-2-4
+
 env:
   global:
     - DOCKER_COMPOSE_VERSION: 1.24.1
@@ -36,3 +43,10 @@ script:
   # Run unit tests
   - cd next
   - npm run test
+  # Run e2e tests
+  - cd e2e
+  - npx cypress verify
+  - npx cypress run -- --record
+
+post_script:
+  - docker-compose stop

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+language: node_js
+
+sudo: required
+
+env:
+  global:
+    - DOCKER_COMPOSE_VERSION: 1.24.1
+
+services:
+  - docker
+
+before_install:
+  # Upgrade docker-compose to the desired version
+  - sudo rm /usr/local/bin/docker-compoose
+  - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
+  - chmod +x docker-compose
+  - sudo mv docker-compose /usr/local/bin
+  # Upgrade docker
+  - sudo apt-get update
+  - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
+
+install:
+  - docker-compose up
+
+script:
+  # Run unit tests
+  - cd next
+  - npm run test


### PR DESCRIPTION
Here's a first pass at a configuration for Travis CI that will automatically run unit and e2e tests. Once all the DO stuff is sorted I'd love to chat with Justin about how I can set this up to handle our deploys as well. :)

We could probably get fancier about node or docker settings to optimize run times, but even this base configuration seems to do a decent job using caches to keep the npm install times down.