### PR TITLE
Add k8s deploy scripts

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -8,7 +8,7 @@ GOOGLE_CALLBACK_URL=http://localhost:3001/auth/google/callback
 GOOGLE_AUTH_SCOPE=https://www.googleapis.com/auth/userinfo.email
 
 # Google Analytics
-GA_TRACKING_ID=UA-142178156-1
+GA_TRACKING_ID=XX-YYYYYYYYY-1
 
 # Domain to get images and other static assets from
 MG_CDN=https://mythgardhub.s3-us-west-2.amazonaws.com

--- a/README.md
+++ b/README.md
@@ -89,3 +89,26 @@ To run all tests:
 ## Development Environment
 
 Please use prettier and eslint. Configs are located in next, express, and e2e, but you will need to `npm install` the necessary eslint plugins.
+
+
+## Deploying
+
+Ensure that the `docker` and `kubectl` commands are installed and in you path.  Docker will need to be configured to push to the `gsdf` organization in the public registry and `kubectl` must be pointed at your target cluster.
+
+First, create a release. E.g.:
+
+```
+scripts/create-release.sh v1.2.3
+```
+
+This will build images for the next and express services, tagged with the appropriate versions, and push them to the docker registry.
+
+To deploy, run:
+
+```
+scripts/deploy.sh v1.2.3
+```
+
+The deploy script instructs the cluster to use images tagged with the given version.
+
+Note that in order to run this script you will have to create the file `kube-config/secrets.sh` that creates/updates a k8s secrets object for use in our deployed containers. This file will not be tracked by version control.

--- a/kube-config/.gitignore
+++ b/kube-config/.gitignore
@@ -1,0 +1,2 @@
+secrets.sh
+secrets.yml

--- a/kube-config/manifest.yml
+++ b/kube-config/manifest.yml
@@ -23,6 +23,7 @@ metadata:
   name: mg-app
 spec:
   replicas: 1
+  revisionHistoryLimit: 3
   template:
     metadata:
       labels:

--- a/kube-config/manifest.yml
+++ b/kube-config/manifest.yml
@@ -1,0 +1,204 @@
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: mg-load-balancer
+spec:
+  type: LoadBalancer
+  selector:
+    app: mg-app
+  ports:
+    - name: https
+      protocol: TCP
+      port: 443
+      targetPort: 3001
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: 3001
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: mg-app
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: mg-app
+    spec:
+      containers:
+        - name: next
+          image: gsdf/mg-next:$VERSION
+          ports:
+            - containerPort: 3001
+              protocol: TCP
+          env:
+            - name: GOOGLE_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: GOOGLE_CLIENT_ID
+            - name: GOOGLE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: GOOGLE_CLIENT_SECRET
+            - name: GOOGLE_CALLBACK_URL
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: GOOGLE_CALLBACK_URL
+            - name: GOOGLE_AUTH_SCOPE
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: GOOGLE_AUTH_SCOPE
+            - name: PGUSER
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: PGUSER
+            - name: PGHOST
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: PGHOST
+            - name: PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: PGPASSWORD
+            - name: PGDATABASE
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: PGDATABASE
+            - name: PGPORT
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: PGPORT
+            - name: PGSSL
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: PGSSL
+            - name: JWT_COOKIE_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: JWT_COOKIE_NAME
+            - name: JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: JWT_SECRET
+            - name: JWT_ISSUER
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: JWT_ISSUER
+            - name: JWT_AUDIENCE
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: JWT_AUDIENCE
+            - name: SSR_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: SSR_HOST
+            - name: API_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: API_HOST
+        - name: express
+          image: gsdf/mg-server:$VERSION
+          ports:
+            - containerPort: 3000
+              protocol: TCP
+          env:
+            - name: GOOGLE_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: GOOGLE_CLIENT_ID
+            - name: GOOGLE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: GOOGLE_CLIENT_SECRET
+            - name: GOOGLE_CALLBACK_URL
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: GOOGLE_CALLBACK_URL
+            - name: GOOGLE_AUTH_SCOPE
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: GOOGLE_AUTH_SCOPE
+            - name: PGUSER
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: PGUSER
+            - name: PGHOST
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: PGHOST
+            - name: PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: PGPASSWORD
+            - name: PGDATABASE
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: PGDATABASE
+            - name: PGPORT
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: PGPORT
+            - name: PGSSL
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: PGSSL
+            - name: JWT_COOKIE_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: JWT_COOKIE_NAME
+            - name: JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: JWT_SECRET
+            - name: JWT_ISSUER
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: JWT_ISSUER
+            - name: JWT_AUDIENCE
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: JWT_AUDIENCE
+            - name: SSR_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: SSR_HOST
+            - name: API_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: API_HOST
+

--- a/kube-config/manifest.yml
+++ b/kube-config/manifest.yml
@@ -207,4 +207,8 @@ spec:
                 secretKeyRef:
                   name: app-secrets
                   key: API_HOST
-
+            - name: MG_CDN
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: MG_CDN

--- a/kube-config/manifest.yml
+++ b/kube-config/manifest.yml
@@ -116,6 +116,11 @@ spec:
                 secretKeyRef:
                   name: app-secrets
                   key: API_HOST
+            - name: MG_CDN
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: MG_CDN
         - name: express
           image: gsdf/mg-server:$VERSION
           ports:

--- a/next/Dockerfile
+++ b/next/Dockerfile
@@ -3,6 +3,7 @@ FROM node:lts-alpine
 WORKDIR /app
 COPY . /app
 
-RUN npm i --production --no-optional && npm run build
+#RUN npm i --production --no-optional && npm run build
+RUN npm i --production --no-optional
 
 CMD ["npm", "start"]

--- a/next/Dockerfile
+++ b/next/Dockerfile
@@ -3,7 +3,6 @@ FROM node:lts-alpine
 WORKDIR /app
 COPY . /app
 
-#RUN npm i --production --no-optional && npm run build
 RUN npm i --production --no-optional
 
 CMD ["npm", "start"]

--- a/next/components/header.js
+++ b/next/components/header.js
@@ -1,7 +1,7 @@
 import Link from 'next/link';
 import { ThemeContext } from './theme-context';
 
-const cdn = `${process.env.MG_CDN}`;
+const cdn = process.env.MG_CDN;
 
 const linkStyle = {
   marginRight: 15

--- a/next/components/with-user.js
+++ b/next/components/with-user.js
@@ -27,7 +27,8 @@ export default WrappedPage => {
          * bundles. Thre should be a "browser" section in our package.json.
          */
         const fetch = require('isomorphic-unfetch');
-        const { JWT_COOKIE_NAME, SSR_HOST } = process.env;
+        const JWT_COOKIE_NAME = process.env.JWT_COOKIE_NAME;
+        const SSR_HOST = process.env.SSR_HOST;
         const token = ctx.req.cookies[JWT_COOKIE_NAME];
         const resp = await fetch(`${SSR_HOST}/auth/user/${token}`);
         user = await resp.json();

--- a/next/next.config.js
+++ b/next/next.config.js
@@ -1,8 +1,10 @@
 module.exports = {
   env: {
-    GA_TRACKING_ID: process.env.GA_TRACKING_ID,
-    USE_GOOGLE_ANALYTICS: process.env.NODE_ENV === 'production',
-    MG_CDN: process.env.MG_CDN
+    API_HOST: process.env.API_HOST,
+    JWT_COOKIE_NAME: process.env.JWT_COOKIE_NAME,
+    MG_CDN: process.env.MG_CDN,
+    SSR_HOST: process.env.SSR_HOST,
+    USE_GOOGLE_ANALYTICS: process.env.NODE_ENV === 'production'
   },
   webpackDevMiddleware: config => {
     config.watchOptions = Object.assign({}, config.watchOptions, {

--- a/next/package.json
+++ b/next/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "node server.js",
     "build": "next build",
-    "start": "NODE_ENV=production node server.js",
+    "start": "npm run build && NODE_ENV=production node server.js",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage"

--- a/next/server-routes/auth.js
+++ b/next/server-routes/auth.js
@@ -4,7 +4,15 @@ const PgClient = require('pg').Client;
 const router = require('express').Router();
 const jwt = require('jsonwebtoken');
 
-const client = new PgClient();
+const client = new PgClient({
+  user: process.env.PGUSER,
+  database: process.env.PGDATABASE,
+  password: process.env.PGPASSWORD,
+  host: process.env.PGHOST,
+  port: process.env.PGPORT,
+  ssl: process.env.PGSSL === 'yes'
+});
+
 client.connect();
 
 passport.use(

--- a/scripts/create-release.sh
+++ b/scripts/create-release.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+# This script builds and pushes images needed for a deployment to docker hub.
+#
+# Usage :
+# 
+#   scripts/create-release.sh <version> 
+#
+# Example
+# 
+#   scripts/create-release.sh v1.2.3
+#
+# You must be able to push to the `gsdf` org on docker hub ot run this script.
+
+VERSION=$1
+
+if test -z "$VERSION"
+then
+  echo ""
+  echo "Usage:"
+  echo ""
+  echo "  scripts/create-release.sh <version>"
+  echo ""
+  echo "E.g.:"
+  echo ""
+  echo "  scripts/create-release.sh v1.2.3"
+  echo ""
+  exit
+fi
+
+echo "Create release for version $VERSION..."
+
+docker build -t "gsdf/mg-next:$VERSION" ./next
+docker build -t "gsdf/mg-server:$VERSION" ./express
+docker push "gsdf/mg-next:$VERSION"
+docker push "gsdf/mg-server:$VERSION"
+
+echo "Done."

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+# This script builds and pushes images needed for a deployment to docker hub.
+#
+# Usage :
+# 
+#   scripts/deploy.sh <version> 
+#
+# Example
+# 
+#   scripts/deploy.sh v1.2.3
+#
+# You must have kubectl configured to work with a k8s cluster to run this
+# script.
+
+VERSION=$1
+
+if test -z "$VERSION"
+then
+  echo ""
+  echo "Usage:"
+  echo ""
+  echo "  scripts/deploy.sh <version>"
+  echo ""
+  echo "E.g.:"
+  echo ""
+  echo "  scripts/deploy.sh v1.2.3"
+  echo ""
+  exit
+fi
+
+echo "Deploying version $VERSION"
+
+source kube-config/secrets.sh
+
+sed s/\$VERSION/"$VERSION"/ kube-config/manifest.yml | kubectl apply -f -


### PR DESCRIPTION
I'm sure there are things in here that are not totally, 100%, all the way, iron clad, best practices.

This is still a manual deploy process, and requires yet another file that is not tracked by version control. Basically the same thing as `.env` except with production values.

Updated the README to include steps to deploy though there is some other configuration you'll need to do as well (mostly to set up the `kubectl` utility). I'll share the prod secrets file with you all too.