### PR TITLE
Restrict account updates to authors

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -21,6 +21,9 @@ PGDATABASE=postgres
 PGPORT=5432
 PGSSL=no
 
+EXPRESS_PGUSER=postgres
+EXPRESS_PGPASSWORD=example
+
 # Configs For JWTs
 JWT_COOKIE_NAME=jwt
 JWT_SECRET=banana_cat_fondue

--- a/.env.template
+++ b/.env.template
@@ -14,9 +14,9 @@ GA_TRACKING_ID=XX-YYYYYYYYY-1
 MG_CDN=https://cdn.mythgardhub.com
 
 # PostgreSQL connection info
-PGUSER=postgres
+PGUSER=postgraphile
 PGHOST=db
-PGPASSWORD=example
+PGPASSWORD=bears4life
 PGDATABASE=postgres
 PGPORT=5432
 PGSSL=no

--- a/.env.template
+++ b/.env.template
@@ -24,6 +24,10 @@ PGSSL=no
 EXPRESS_PGUSER=postgres
 EXPRESS_PGPASSWORD=example
 
+# Roles assumed by Postgraphile for making DB requests
+PG_AUTHD_USER_ROLE=authd_user
+PG_ANON_USER_ROLE=anon_user
+
 # Configs For JWTs
 JWT_COOKIE_NAME=jwt
 JWT_SECRET=banana_cat_fondue

--- a/express/index.js
+++ b/express/index.js
@@ -27,7 +27,7 @@ app.use(
       jwtVerifyOptions: {
         audience: [process.env.JWT_AUDIENCE]
       },
-      pgDefaultRole: 'anon_user'
+      pgDefaultRole: process.env.PG_ANON_USER_ROLE
     }
   )
 );

--- a/express/index.js
+++ b/express/index.js
@@ -22,7 +22,12 @@ app.use(
       graphileBuildOptions: {
         connectionFilterAllowNullInput: true,
         connectionFilterRelations: true
-      }
+      },
+      jwtSecret: process.env.JWT_SECRET,
+      jwtVerifyOptions: {
+        audience: [process.env.JWT_AUDIENCE]
+      },
+      pgDefaultRole: 'anon_user'
     }
   )
 );

--- a/next/package-lock.json
+++ b/next/package-lock.json
@@ -1631,6 +1631,15 @@
         "tslib": "^1.9.3"
       }
     },
+    "apollo-link-context": {
+      "version": "1.0.18",
+      "resolved": "https://registry.npmjs.org/apollo-link-context/-/apollo-link-context-1.0.18.tgz",
+      "integrity": "sha512-aG5cbUp1zqOHHQjAJXG7n/izeMQ6LApd/whEF5z6qZp5ATvcyfSNkCfy3KRJMMZZ3iNfVTs6jF+IUA8Zvf+zeg==",
+      "requires": {
+        "apollo-link": "^1.2.12",
+        "tslib": "^1.9.3"
+      }
+    },
     "apollo-link-error": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/apollo-link-error/-/apollo-link-error-1.1.11.tgz",
@@ -4459,8 +4468,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4478,13 +4486,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4497,18 +4503,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4611,8 +4614,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4622,7 +4624,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4635,20 +4636,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4665,7 +4663,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4738,8 +4735,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4749,7 +4745,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4825,8 +4820,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4856,7 +4850,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4874,7 +4867,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4913,13 +4905,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },
@@ -8259,14 +8249,6 @@
             "react-is": "^16.8.1"
           }
         }
-      }
-    },
-    "react-apollo-hooks": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/react-apollo-hooks/-/react-apollo-hooks-0.5.0.tgz",
-      "integrity": "sha512-Us5KqFe7/c6vY1NaiyfhnD2Pz4lPLTojQXLppShaBVYU/vYvJrRjmj4MzIPXnExXaSfnQ+K2bWDr4lP4efbsRQ==",
-      "requires": {
-        "lodash": "^4.17.11"
       }
     },
     "react-apollo-hooks": {

--- a/next/package.json
+++ b/next/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "apollo-boost": "^0.4.4",
     "apollo-link-batch-http": "^1.2.12",
+    "apollo-link-context": "^1.0.18",
     "cookie-parser": "^1.4.4",
     "express": "4.17.x",
     "express-http-proxy": "^1.5.1",

--- a/next/server-routes/auth.js
+++ b/next/server-routes/auth.js
@@ -86,7 +86,7 @@ router.get(
       {
         // Aging these out after 1 day for now
         exp: Math.floor(Date.now() / 1000 + 24 * 60 * 60),
-        role: 'authd_user',
+        role: process.env.PG_AUTHD_USER_ROLE,
         ...user
       },
       process.env.JWT_SECRET,

--- a/next/server-routes/auth.js
+++ b/next/server-routes/auth.js
@@ -110,7 +110,6 @@ router.get('/user', async (req, res) => {
   let user;
   try {
     const token = jwt.verify(signedToken, process.env.JWT_SECRET);
-    console.log(token);
     user = await getUserByEmail(token.email);
   } catch (err) {
     res.json(null);

--- a/postgres/init.sql
+++ b/postgres/init.sql
@@ -118,8 +118,6 @@ CREATE POLICY accountupdate_if_author
   USING ("id" = mythgard.current_user_id())
   WITH CHECK ("id" = mythgard.current_user_id());
 
-GRANT SELECT (id, email, username) on mythgard.account TO authd_user;
-
 CREATE TABLE mythgard.tournament (
   id SERIAL PRIMARY KEY,
   name varchar(255),
@@ -192,7 +190,17 @@ GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA mythgard TO postgraphile;
 GRANT authd_user TO postgraphile;
 GRANT anon_user TO postgraphile;
 
+GRANT ALL PRIVILEGES ON SCHEMA mythgard TO admin;
 GRANT ALL PRIVILEGES ON SCHEMA mythgard TO authd_user;
 GRANT ALL PRIVILEGES ON SCHEMA mythgard TO anon_user;
+GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA mythgard TO admin;
 GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA mythgard TO authd_user;
 GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA mythgard TO anon_user;
+
+-- Set specific permissions for sensitive tables
+REVOKE ALL PRIVILEGES ON TABLE mythgard.account FROM authd_user;
+REVOKE ALL PRIVILEGES ON TABLE mythgard.account FROM anon_user;
+
+GRANT SELECT ON TABLE mythgard.account TO authd_user;
+GRANT UPDATE (username) ON TABLE mythgard.account TO authd_user;
+GRANT SELECT (id, username) ON TABLE mythgard.account TO anon_user;

--- a/postgres/init.sql
+++ b/postgres/init.sql
@@ -4,6 +4,10 @@ CREATE SCHEMA mythgard;
 
 CREATE TYPE mythgard.rarity AS ENUM ('common', 'uncommon', 'rare', 'mythic');
 
+CREATE ROLE admin;
+CREATE ROLE authd_user;
+CREATE ROLE anon_user;
+
 CREATE TABLE mythgard.card (
   id SERIAL PRIMARY KEY,
   name varchar(255),
@@ -96,6 +100,26 @@ RETURNS mythgard.account as $$
     RETURNING *
 $$ LANGUAGE sql VOLATILE;
 
+CREATE OR REPLACE FUNCTION mythgard.current_user_id()
+RETURNS integer as $$
+  SELECT nullif(current_setting('jwt.claims.userId', true), '')::integer;
+$$ language sql stable;
+
+ALTER TABLE mythgard.account ENABLE ROW LEVEL SECURITY;
+
+-- Admin users can make any changes and read all rows
+CREATE POLICY admin_all ON mythgard.account TO admin USING (true) WITH CHECK (true);
+-- Non-admins can read all rows
+CREATE POLICY all_view ON mythgard.account FOR SELECT USING (true);
+-- Rows can only be updated by their author
+CREATE POLICY accountupdate_if_author
+  ON mythgard.account
+  FOR UPDATE
+  USING ("id" = mythgard.current_user_id())
+  WITH CHECK ("id" = mythgard.current_user_id());
+
+GRANT SELECT (id, email, username) on mythgard.account TO authd_user;
+
 CREATE TABLE mythgard.tournament (
   id SERIAL PRIMARY KEY,
   name varchar(255),
@@ -156,3 +180,19 @@ $$ language 'plpgsql';
 CREATE TRIGGER update_deck_modtime
   BEFORE UPDATE ON mythgard.deck
   FOR EACH ROW EXECUTE PROCEDURE update_modified_column();
+
+-- Create a user for Postgraphile to connect as which has permissions
+-- to the mythgard schema
+
+CREATE USER postgraphile WITH password 'bears4life';
+GRANT ALL PRIVILEGES ON SCHEMA mythgard TO postgraphile;
+GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA mythgard TO postgraphile;
+
+-- The Postgraphile user needs privileges to set role for itself
+GRANT authd_user TO postgraphile;
+GRANT anon_user TO postgraphile;
+
+GRANT ALL PRIVILEGES ON SCHEMA mythgard TO authd_user;
+GRANT ALL PRIVILEGES ON SCHEMA mythgard TO anon_user;
+GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA mythgard TO authd_user;
+GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA mythgard TO anon_user;


### PR DESCRIPTION
Sorry that this one was a long time coming. It took some time for me to figure out how to get things working but fortunately I've learned a lot along the way.

First off, some things to be aware of:

- There are updates to the `.env` that need to be made. You can see the changes in the template file.
- There is a new node module dep in the `next` project.

I can add a wiki page to document some of this if it would help, but roughly how this works is:

- The JWT cookie (when available) is sent as an `Authorization` request header for all GraphQL requests
- Postgraphile verifies and reads the auth header and extracts all of the claims in it as properties. It also reads the "role" claim to set a Postgres role.
- I've created three high-level postgres roles: `admin` (for future use, nothing sets this role atm), `authd_user` (for logged in users), and `anon_user` (for non-authenticated users). You can grant or deny various permissions to the DB schema, tables, etc. to each of these roles. In this PR, only admins and logged in users can update the account table.
- Row level policies are put in place so that users can only update the account which they are currently logged in as. These policies can read the claims made in the JWT using `current_setting`.

Some gotchas that might be good to be aware of:

- Table owners generally bypass all row level security policies. This is why Postgraphile now logs in to the DB with a different user than the one that creates the DB.
- As soon as you enable row level security on a table, it assumes a default deny everything policy, so you will need to make sure the needed roles have the appropriate privileges to even be able to do anything including read any row.
