### PR TITLE
Add clear filters to the decks list page

### DIFF
--- a/e2e/cypress/integration/decks-page.js
+++ b/e2e/cypress/integration/decks-page.js
@@ -99,4 +99,79 @@ describe('Decks Page', function() {
         });
     });
   });
+
+  it('should search for decks and clear filters', function() {
+    cy.get('[data-cy="deckSearchUpdatedTime"]').select('100000');
+    cy.get('[data-cy="deckListItem"]').then(list => {
+      // test deck name search
+      const initialListLength = list.length;
+      cy.get('[data-cy="deckSearchDeckName"]').type('cat');
+      cy.get('[data-cy="deckSearchSubmit"]').click();
+      cy.get('[data-cy="deckListItem"]').should('have.length', 1);
+      cy.get('[data-cy="deckListItem"] a').should('contain', 'cat');
+      cy.get(deckFactionsPicker).should('have.length', '1');
+      cy.get(deckManaPicker).should('contain', '3');
+      cy.get('[data-cy="deckSearchClear"]').click();
+      cy.get('[data-cy="deckListItem"]').should(
+        'have.length',
+        initialListLength
+      );
+
+      // test search by card name included
+      let lengthAfterOneFilter;
+      cy.get(`${cardSearch} input`).type('drag');
+      cy.get(`${cardSearch} input`).type('{enter}');
+      cy.get(cardSearchSelections).should('have.length', 1);
+      cy.get('[data-cy="deckSearchSubmit"]').click();
+      cy.get('[data-cy="deckListItem"]')
+        .then(cards => {
+          lengthAfterOneFilter = cards.length;
+          expect(lengthAfterOneFilter).to.be.lessThan(initialListLength);
+          cy.get(`${cardSearch} input`).type('harm');
+          cy.get(`${cardSearch} input`).type('{enter}');
+          cy.get(cardSearchSelections).should('have.length', 2);
+          cy.get('[data-cy="deckSearchSubmit"]').click();
+          return cy.get('[data-cy="deckListItem"]');
+        })
+        .then(cards => {
+          expect(cards.length).to.be.lessThan(lengthAfterOneFilter);
+        })
+        .then(() => {
+          cy.get(`${cardSearchSelections} button`).should('have.length', 2);
+          cy.get(deckFactionsPicker).should('have.length', '6');
+          cy.get(deckManaPicker).should('contain', '10');
+          cy.get('[data-cy="deckSearchClear"]').click();
+          cy.get('[data-cy="deckListItem"]').should(
+            'have.length',
+            initialListLength
+          );
+
+          // test deck faction search
+          cy.get(`${factionFilter}:first`).click();
+          cy.get('[data-cy="deckSearchSubmit"]').click();
+          return cy.get('[data-cy="deckListItem"]');
+        })
+        .then(cards => {
+          expect(cards.length).to.be.lessThan(initialListLength);
+          cy.get('[data-cy="deckSearchClear"]').click();
+          cy.get('[data-cy="deckListItem"]').should(
+            'have.length',
+            initialListLength
+          );
+
+          // test deck author search
+          cy.get('[data-cy="deckSearchDeckAuthor"]').type('lsv');
+          cy.get('[data-cy="deckSearchSubmit"]').click();
+          return cy.get('[data-cy="deckListItem"]');
+        })
+        .then(cards => {
+          expect(cards.length).to.be.lessThan(initialListLength);
+          cy.get('[data-cy="deckSearchClear"]').click();
+          cy.get('[data-cy="deckListItem"]').should(
+            'have.length',
+            initialListLength
+          );
+        });
+    });
+  });
 });

--- a/next/components/deck-search-form.js
+++ b/next/components/deck-search-form.js
@@ -30,6 +30,17 @@ export default function DeckSearchForm(props) {
     });
   };
 
+  const handleClear = e => {
+    e && e.preventDefault();
+    setName('');
+    setCardIds([]);
+    setFactionNames([]);
+    setIsOnlyFactions(true);
+    setUpdatedTime('150');
+    setAuthorName('');
+    onSubmit({});
+  };
+
   const { error, data } = useQuery(allCardsQuery);
 
   let cardSearchElement = null;
@@ -117,7 +128,9 @@ export default function DeckSearchForm(props) {
           value="Apply"
           onClick={handleSubmit}
         />
-        <button>Clear</button>
+        <button onClick={handleClear} data-cy="deckSearchClear">
+          Clear
+        </button>
       </div>
     </form>
   );

--- a/next/components/deck-search-form.js
+++ b/next/components/deck-search-form.js
@@ -30,8 +30,7 @@ export default function DeckSearchForm(props) {
     });
   };
 
-  const handleClear = e => {
-    e && e.preventDefault();
+  const handleClear = () => {
     setName('');
     setCardIds([]);
     setFactionNames([]);
@@ -128,7 +127,7 @@ export default function DeckSearchForm(props) {
           value="Apply"
           onClick={handleSubmit}
         />
-        <button onClick={handleClear} data-cy="deckSearchClear">
+        <button type="button" onClick={handleClear} data-cy="deckSearchClear">
           Clear
         </button>
       </div>

--- a/next/lib/deck-queries.js
+++ b/next/lib/deck-queries.js
@@ -111,6 +111,7 @@ export const getDeckSearchQuery = (
           author {
             username
           }
+          modified
           cardDecks {
             nodes {
               quantity

--- a/next/pages/decks.js
+++ b/next/pages/decks.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import AllDecks from '../components/all-decks';
 import DeckSearchForm from '../components/deck-search-form';
 import SomeDecks from '../components/some-decks';
@@ -16,36 +16,28 @@ const hasSearch = function(searchQuery) {
   );
 };
 
-class DecksPage extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {};
-    this.handlSearchSubmit = this.handleSearchSubmit.bind(this);
-  }
+export default function DecksPage() {
+  const [searchQuery, setSearchQuery] = useState({});
 
-  handleSearchSubmit(searchQuery) {
-    this.setState({ searchQuery });
-  }
+  const handleSearchSubmit = searchQuery => {
+    setSearchQuery(searchQuery);
+  };
 
-  render() {
-    return (
-      <Layout title="Mythgard Hub | Decks" desc="Browse Mythgard decks">
-        <style jsx>{`
-          h1 {
-            margin: 20px 0 25px 0;
-          }
-        `}</style>
-        <PageBanner image={PageBanner.IMG_DECKS}>Decks</PageBanner>
-        <DeckSearchForm onSubmit={this.handleSearchSubmit.bind(this)} />
-        <h1>Results</h1>
-        {hasSearch(this.state.searchQuery) ? (
-          <SomeDecks search={this.state.searchQuery} />
-        ) : (
-          <AllDecks />
-        )}
-      </Layout>
-    );
-  }
+  return (
+    <Layout title="Mythgard Hub | Decks" desc="Browse Mythgard decks">
+      <style jsx>{`
+        h1 {
+          margin: 20px 0 25px 0;
+        }
+      `}</style>
+      <PageBanner image={PageBanner.IMG_DECKS}>Decks</PageBanner>
+      <DeckSearchForm onSubmit={handleSearchSubmit} />
+      <h1>Results</h1>
+      {hasSearch(searchQuery) ? (
+        <SomeDecks search={searchQuery} />
+      ) : (
+        <AllDecks />
+      )}
+    </Layout>
+  );
 }
-
-export default DecksPage;


### PR DESCRIPTION
This clears the filters BUT it doesn't work well on the card search one, since it seems like it handles its own state. The card ids are cleared but your selection and the suggestions are still there... I think it will require some more refactoring to basically make it not be the master of its own state so I figured I'll make another PR for that.