### PR TITLE
Query whitelisting  - waiting on deck search rewrite to merge

### DIFF
--- a/express/index.js
+++ b/express/index.js
@@ -4,43 +4,18 @@ const PgSimplifyInflectorPlugin = require('@graphile-contrib/pg-simplify-inflect
 const ConnectionFilterPlugin = require('postgraphile-plugin-connection-filter');
 const compression = require('compression');
 const helmet = require('helmet');
+const { hashQuery, allowedQueryHashes } = require('./query-checker.js');
 
 const app = express();
 
 app.use(compression());
 app.use(helmet());
 
-// prettier-ignore
-// eslint-disable-next-line
-const jhashcode=s=>{for(var i=0,h;i<s.length;i++)h=Math.imul(31,h)+s.charCodeAt(i)|0;return h};
-
-const allowedQueryHashes = [
-  -1521083219,
-  -1223515326,
-  1435166661,
-  23960061,
-  539470254,
-  -1987618902,
-  436396872,
-  987565251,
-  610459161,
-  1379591156,
-  569291494,
-  -2034784358,
-  594499639,
-  -1278945283,
-  -1204701883,
-  1952576784
-];
-
 app.use(express.json());
 app.use('/graphql', async (req, res, next) => {
   const queries = req.body.map(b => b.query);
   const allQueriesOk = queries.reduce((acc, query) => {
-    query = query.trim();
-    const hash = jhashcode(query);
-    console.log('query: ', `***${query}***`);
-    console.log('hash: ', hash);
+    const hash = hashQuery(query);
     return acc && allowedQueryHashes.includes(hash);
   }, true);
   if (!allQueriesOk) {

--- a/express/index.js
+++ b/express/index.js
@@ -10,6 +10,45 @@ const app = express();
 app.use(compression());
 app.use(helmet());
 
+// prettier-ignore
+// eslint-disable-next-line
+const jhashcode=s=>{for(var i=0,h;i<s.length;i++)h=Math.imul(31,h)+s.charCodeAt(i)|0;return h};
+
+const allowedQueryHashes = [
+  -1521083219,
+  -1223515326,
+  1435166661,
+  23960061,
+  539470254,
+  -1987618902,
+  436396872,
+  987565251,
+  610459161,
+  1379591156,
+  569291494,
+  -2034784358,
+  594499639,
+  -1278945283,
+  -1204701883,
+  1952576784
+];
+
+app.use(express.json());
+app.use('/graphql', async (req, res, next) => {
+  const queries = req.body.map(b => b.query);
+  const allQueriesOk = queries.reduce((acc, query) => {
+    query = query.trim();
+    const hash = jhashcode(query);
+    console.log('query: ', `***${query}***`);
+    console.log('hash: ', hash);
+    return acc && allowedQueryHashes.includes(hash);
+  }, true);
+  if (!allQueriesOk) {
+    res.json({ error: `query not on whitelist` });
+  }
+  next();
+});
+
 app.use(
   postgraphile(
     {

--- a/express/index.js
+++ b/express/index.js
@@ -21,7 +21,7 @@ app.use('/graphql', async (req, res, next) => {
   const allQueriesOk = queries.reduce((acc, query) => {
     const hash = hashQuery(query);
     const allowed = allowedQueryHashes.includes(hash);
-    if (!allowed) {
+    if (!allowed && process.env.DEBUG) {
       console.log('Bad query detected!!!');
       console.log('query: ', query);
       console.log('normalized: ', normalizeString(query));

--- a/express/query-checker.js
+++ b/express/query-checker.js
@@ -4,12 +4,17 @@ const allowedQueries = require('./whitelisted-queries.js');
 // eslint-disable-next-line
 const jhashcode=s=>{for(var i=0,h;i<s.length;i++)h=Math.imul(31,h)+s.charCodeAt(i)|0;return h};
 
-const hashQuery = q =>
-  jhashcode(q.replace(/\s/g, '').replace(/__typename/g, ''));
+// graphql or apollo tend to add stuff to queries that
+// can change the string, thus changing the hash.
+// remove commas, whitespace, and __typename.
+const normalizeString = s => s.replace(/[,\s]/g, '').replace(/__typename/g, '');
+
+const hashQuery = q => jhashcode(normalizeString(q));
 
 const allowedQueryHashes = allowedQueries.map(hashQuery);
 
 module.exports = {
   hashQuery,
+  normalizeString,
   allowedQueryHashes
 };

--- a/express/query-checker.js
+++ b/express/query-checker.js
@@ -1,0 +1,15 @@
+const allowedQueries = require('./whitelisted-queries.js');
+
+//prettier-ignore
+// eslint-disable-next-line
+const jhashcode=s=>{for(var i=0,h;i<s.length;i++)h=Math.imul(31,h)+s.charCodeAt(i)|0;return h};
+
+const hashQuery = q =>
+  jhashcode(q.replace(/\s/g, '').replace(/__typename/g, ''));
+
+const allowedQueryHashes = allowedQueries.map(hashQuery);
+
+module.exports = {
+  hashQuery,
+  allowedQueryHashes
+};

--- a/express/whitelisted-queries.js
+++ b/express/whitelisted-queries.js
@@ -1,7 +1,3 @@
-//prettier-ignore
-// eslint-disable-next-line
-const jhashcode=s=>{for(var i=0,h;i<s.length;i++)h=Math.imul(31,h)+s.charCodeAt(i)|0;return h};
-
 const deckPreviewsFragment = `
   deckPreviews {
     nodes {
@@ -18,7 +14,8 @@ const deckPreviewsFragment = `
     }
   }`;
 
-const queriesWhitelist = [
+// whitespace doesn't matter here.
+module.exports = [
   `
   query tournaments {
     tournaments(orderBy: DATE_DESC) {
@@ -324,8 +321,4 @@ const queriesWhitelist = [
     }
   }
 `
-]
-  .map(s => s.trim())
-  .map(jhashcode);
-
-console.log(queriesWhitelist);
+];

--- a/scripts/generate-queries-whitelist.js
+++ b/scripts/generate-queries-whitelist.js
@@ -1,3 +1,23 @@
+//prettier-ignore
+// eslint-disable-next-line
+const jhashcode=s=>{for(var i=0,h;i<s.length;i++)h=Math.imul(31,h)+s.charCodeAt(i)|0;return h};
+
+const deckPreviewsFragment = `
+  deckPreviews {
+    nodes {
+      deckName
+      deckCreated
+      factions
+      essenceCost
+      deck{
+        author {
+          username
+          id
+        }
+      }
+    }
+  }`;
+
 const queriesWhitelist = [
   `
   query tournaments {
@@ -304,4 +324,8 @@ const queriesWhitelist = [
     }
   }
 `
-];
+]
+  .map(s => s.trim())
+  .map(jhashcode);
+
+console.log(queriesWhitelist);

--- a/scripts/generate-queries-whitelist.js
+++ b/scripts/generate-queries-whitelist.js
@@ -1,0 +1,307 @@
+const queriesWhitelist = [
+  `
+  query tournaments {
+    tournaments(orderBy: DATE_DESC) {
+      nodes {
+        id
+        name
+        date
+      }
+    }
+  }
+`,
+  `
+  mutation UpdateAccountUsername($accountId: Int!, $username: String!) {
+    updateAccount(
+      input: {
+        id: $accountId
+        patch: {
+          username: $username
+        }
+      }
+    ) {
+      account {
+        id
+        email
+        username
+      }
+    }
+  }
+`,
+  `
+  mutation DeleteDeck($deckId: Int!) {
+    deleteDeck(input: { id: $deckId }) {
+      deletedDeckNodeId
+    }
+  }
+`,
+  `
+  mutation CreateCardDeck($deckId: Int!, $cardId: Int!, $quantity: Int!) {
+    createCardDeck(
+      input: {
+        cardDeck: { deckId: $deckId, cardId: $cardId, quantity: $quantity }
+      }
+    ) {
+      cardDeck {
+        quantity
+        deckId
+        cardId
+      }
+    }
+  }
+`,
+
+  `
+  mutation AddDeck(
+    $name: String!
+    $pathId: Int
+    $powerId: Int
+    $authorId: Int
+  ) {
+    createDeck(
+      input: {
+        deck: {
+          name: $name
+          pathId: $pathId
+          powerId: $powerId
+          authorId: $authorId
+        }
+      }
+    ) {
+      deck {
+        id
+        name
+        author {
+          id
+          username
+        }
+        path {
+          id
+          name
+        }
+        power {
+          id
+          name
+        }
+      }
+    }
+  }
+`,
+
+  `
+  query powers {
+    powers {
+      nodes {
+        id
+        name
+        rules
+      }
+    }
+  }
+`,
+
+  `
+  query paths {
+    paths {
+      nodes {
+        id
+        name
+        rules
+      }
+    }
+  }
+`,
+
+  `
+  query cards {
+    cards {
+      nodes {
+        id
+        name
+        mana
+        gem
+      }
+    }
+  }
+`,
+
+  `
+    query cards(
+      $searchText: String
+      $rarities: [Rarity!]
+      $factionIds: [String!]
+      $manaCosts: [Int!]
+      $strengths: [Int!]
+      $defenses: [Int!]
+      $supertypes: [Cardtype]
+      $manaGTE: Int
+      $strengthGTE: Int
+      $defenseGTE: Int
+    ) {
+      cards(
+        filter: {
+          and: [
+            {
+              or: [
+                { name: { includesInsensitive: $searchText } }
+                { rules: { includesInsensitive: $searchText } }
+              ]
+            }
+            {
+              or: [
+                { mana: { in: $manaCosts } }
+                { mana: { greaterThanOrEqualTo: $manaGTE } }
+              ]
+            }
+            {
+              or: [
+                { atk: { in: $strengths } }
+                { atk: { greaterThanOrEqualTo: $strengthGTE } }
+              ]
+            }
+            {
+              or: [
+                { def: { in: $defenses } }
+                { def: { greaterThanOrEqualTo: $defenseGTE } }
+              ]
+            }
+          ]
+          rarity: { in: $rarities }
+          supertype: { containedBy: $supertypes }
+          cardFactions: { some: { faction: { name: { in: $factionIds } } } }
+        }
+      ) {
+        nodes {
+          name
+          id
+        }
+      }
+    }
+  `,
+
+  `
+  query($id: Int!) {
+    deck(id: $id) {
+      id
+      name
+      cardDecks {
+        nodes {
+          quantity
+          card {
+            name
+            id
+          }
+        }
+      }
+    }
+  }
+`,
+
+  `
+  query decks {
+    decks {
+      nodes {
+        id
+        name
+        author {
+          username
+        }
+        modified
+        cardDecks {
+          nodes {
+            quantity
+            card {
+              mana
+              cardFactions {
+                nodes {
+                  faction {
+                    name
+                  }
+                }
+              }
+            }
+          }
+        }
+        ${deckPreviewsFragment}
+      }
+    }
+  }
+`,
+
+  `
+  query($id: Int!) {
+    tournament(id: $id) {
+      tournamentDecks(orderBy: RANK_ASC, first: 8) {
+        nodes {
+          rank
+          deck {
+            id
+            name
+            author {
+              username
+            }
+          }
+        }
+      }
+    }
+  }
+`,
+
+  `
+  query deck($id: Int!) {
+    deck(id: $id) {
+      id
+      name
+      author {
+        id
+        username
+      }
+      power {
+        name
+      }
+      path {
+        name
+      }
+    }
+  }
+`,
+
+  `
+  query deckPreview {
+    deckPreviews(orderBy: DECK_CREATED_DESC, first: 3) {
+      nodes {
+        deckName
+        deckCreated
+        factions
+        essenceCost
+        deck {
+          author {
+            username
+            id
+          }
+        }
+      }
+    }
+  }
+`,
+
+  `
+  query tournament($id: Int!) {
+    tournament(id: $id) {
+      id
+      name
+    }
+  }
+`,
+
+  `
+  query card($id: Int!) {
+    card(id: $id) {
+      name
+      atk
+      def
+      rules
+    }
+  }
+`
+];


### PR DESCRIPTION
Note that currently the deck search is not whitelist-able, so it's broken right now. I will start working on that next. 

Obviously this is not ideal since we have to keep the whitelist file in sync with our next.js stuff, but it's a start. LMK if you have any better ideas for doing this. There are some automated tools, but we'd need to start using .graphql files and that seems like a big can of worms to open (need to move all of our queries into .graphql files and teach webpack how to handle them, and probably some additional stuff - I gave up at that point).