### PR TITLE
Keep "session" alive while user is active

### DIFF
--- a/next/pages/_app.js
+++ b/next/pages/_app.js
@@ -31,7 +31,8 @@ class MyApp extends App {
        * bundles. Thre should be a "browser" section in our package.json.
        */
       const fetch = require('isomorphic-unfetch');
-      const { JWT_COOKIE_NAME, SSR_HOST } = process.env;
+      const JWT_COOKIE_NAME = process.env.JWT_COOKIE_NAME;
+      const SSR_HOST = process.env.SSR_HOST;
       const token = ctx.req.cookies[JWT_COOKIE_NAME];
       const resp = await fetch(`${SSR_HOST}/auth/user/${token}`);
       user = await resp.json();
@@ -60,6 +61,20 @@ class MyApp extends App {
   updateUser = user => {
     this.setState({ user });
   };
+
+  componentDidMount() {
+    this.userCheckInterval = setInterval(() => {
+      if (!this.state.user) return;
+      const r = new RegExp(`\\b${process.env.JWT_COOKIE_NAME}\\b`);
+      if (!r.test(document.cookie)) {
+        this.setState({ user: null });
+      }
+    }, 5000);
+  }
+
+  componentWillUnmount() {
+    clearInterval(this.userCheckInterval);
+  }
 
   render() {
     const { Component, pageProps, apolloClient } = this.props;

--- a/next/pages/_app.js
+++ b/next/pages/_app.js
@@ -63,6 +63,8 @@ class MyApp extends App {
   };
 
   componentDidMount() {
+    // Don't bother with the interval if we're not signed in
+    if (!this.state.user) return;
     this.userCheckInterval = setInterval(() => {
       if (!this.state.user) return;
       const r = new RegExp(`\\b${process.env.JWT_COOKIE_NAME}\\b`);


### PR DESCRIPTION
This change does two things:

- Updates the JWT cookie expiration time whenever the user makes a request
- Clears the JWT cookie if it detects it is not longer valid (i.e. expired)

Since user info lives in the state of `_app`, there's also an interval to check to make sure that cookie still exists. Once the cookie gets eaten, the app will show you as being logged out.

Side note:

A best practice would be to instead maintain two separate JWTs. One with a long expiration time (maybe 7 days) and another with short fuse (e.g. 15 minutes). The longer living token grants you permission to request a short-lived token. The short-lived token would then give you access to app APIs. The rationale behind this strategy is that you get to revoke user access (within a 15-minute lag) while still not constantly hitting your DB or the auth provider with every request. This lets you do fancy things like sign folks out when you delete their account, otherwise they might be able to keep their session alive indefinitely... perhaps a fun consideration for down the road 😅. 