### PR TITLE
Fix prop type warnings and style tweak

### DIFF
--- a/next/components/footer.js
+++ b/next/components/footer.js
@@ -23,14 +23,17 @@ export default function Footer() {
           text-decoration: none;
           color: ${theme.footerLinkColor};
         }
+
+        * + *:before {
+          content: '|';
+          color: ${theme.footerTextColor};
+          margin: 0 2px;
+        }
       `}</style>
-      &copy; {new Date().getFullYear()} Mythgard |{' '}
-      <Link>
-        <a href={`mailto:${process.env.EMAIL_MG_SUPPORT}`}>Contact</a>
-      </Link>{' '}
-      |{' '}
-      <Link>
-        <a href="/privacy-policy">Privacy Policy</a>
+      <span>&copy; {new Date().getFullYear()} Mythgard</span>
+      <a href={`mailto:${process.env.EMAIL_MG_SUPPORT}`}>Contact</a>
+      <Link href="/privacy-policy">
+        <a>Privacy Policy</a>
       </Link>
     </div>
   );

--- a/next/components/page-banner.js
+++ b/next/components/page-banner.js
@@ -36,7 +36,6 @@ PageBanner.IMG_PATCH_NOTES = `${process.env.MG_CDN}/banner/Banner_PatchNotes.jpg
 PageBanner.IMG_HOME_TOP = `${process.env.MG_CDN}/banner/Banner_Home_Top.jpg`;
 
 PageBanner.propTypes = {
-  children: PropTypes.string,
   image: PropTypes.oneOf([
     PageBanner.IMG_ARTICLES,
     PageBanner.IMG_CARDS,

--- a/next/pages/index.js
+++ b/next/pages/index.js
@@ -51,9 +51,9 @@ const index = () => {
         <Link href="/patchNotes">
           <a>
             <PageBanner image={PageBanner.IMG_PATCH_NOTES}>
-                Latest Patch Notes
-                <br />
-                v0.0.1
+              Latest Patch Notes
+              <br />
+              v0.0.1
             </PageBanner>
           </a>
         </Link>

--- a/next/pages/index.js
+++ b/next/pages/index.js
@@ -51,9 +51,9 @@ const index = () => {
         <Link href="/patchNotes">
           <a>
             <PageBanner image={PageBanner.IMG_PATCH_NOTES}>
-              Latest Patch Notes
-              <br />
-              v0.0.1
+                Latest Patch Notes
+                <br />
+                v0.0.1
             </PageBanner>
           </a>
         </Link>


### PR DESCRIPTION
The page-banner component was marked as wanting only `string` children.
It now allows anything.

I made a little change to the footer styles while I was fixing the
prop-type warnings on the links there too.