### PR TITLE
Preserve decks built while user is not logged in

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -25,6 +25,7 @@ PGSSL=no
 
 EXPRESS_PGUSER=postgres
 EXPRESS_PGPASSWORD=example
+EXPRESS_SESSION_SECRET=owl_chEEse_7
 
 # Roles assumed by Postgraphile for making DB requests
 PG_AUTHD_USER_ROLE=authd_user

--- a/e2e/cypress/integration/deck-builder-page.js
+++ b/e2e/cypress/integration/deck-builder-page.js
@@ -16,7 +16,11 @@ import {
 
 describe('Deck builder page', () => {
   beforeEach(() => {
-    cy.visit('/deck-builder');
+    cy.visit('/deck-builder', {
+      onBeforeLoad: win => {
+        win.sessionStorage.clear();
+      }
+    });
   });
   it('should have a happy path', function() {
     cy.get('[data-cy="header"]').should('be.visible');
@@ -123,15 +127,6 @@ describe('Deck builder page', () => {
       })
       .then(length => {
         expect(numCardsBeforeFilter).to.equal(length);
-
-        // finally try to save the deck and fail
-        cy.get('[data-cy="deckTitle"]').type('Floop the Pig');
-        cy.get('[data-cy="saveDeck"]').click();
-        cy.on('window:alert', str => {
-          expect(str).to.equal(
-            'Only logged in users can save deck. Please export your work, log in and come back.'
-          );
-        });
       });
   });
 

--- a/next/components/layout.js
+++ b/next/components/layout.js
@@ -81,7 +81,8 @@ function Layout({ title, desc, children }) {
           }
 
           button,
-          input[type='submit'] {
+          input[type='submit'],
+          a.button {
             background-color: ${theme.sectionBackground};
             border: ${theme.sectionBorder};
             color: ${theme.buttonTextColor};
@@ -94,6 +95,9 @@ function Layout({ title, desc, children }) {
             border-radius: 10px;
             font-style: italic;
             cursor: pointer;
+            text-decoration: none;
+            display: inline-block;
+            text-align: center;
           }
 
           button:disabled {

--- a/next/components/save-deck.js
+++ b/next/components/save-deck.js
@@ -2,6 +2,7 @@ import { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { ApolloConsumer } from 'react-apollo';
 import Router from 'next/router';
+import Link from 'next/link';
 
 import UserContext from '../components/user-context';
 import createNewEmptyDeck from '../lib/mutations/add-deck';
@@ -45,13 +46,18 @@ export default function SaveDeck({ deckInProgress }) {
     return Boolean(deckInProgress.deckName);
   };
 
-  return (
-    <div className="save-deck-container">
-      <style jsx>{`
-        .save-deck-container {
-          margin-bottom: 10px;
-        }
-      `}</style>
+  // If user is not logged in, they must do so before saving
+  let saveButton;
+  if (!user || !user.id) {
+    saveButton = (
+      <Link href="/auth/google">
+        <a className="button" data-cy="saveDeck">
+          Login to Save
+        </a>
+      </Link>
+    );
+  } else {
+    saveButton = (
       <ApolloConsumer>
         {client => (
           <button
@@ -65,6 +71,17 @@ export default function SaveDeck({ deckInProgress }) {
           </button>
         )}
       </ApolloConsumer>
+    );
+  }
+
+  return (
+    <div className="save-deck-container">
+      <style jsx>{`
+        .save-deck-container {
+          margin-bottom: 10px;
+        }
+      `}</style>
+      {saveButton}
     </div>
   );
 }

--- a/next/package-lock.json
+++ b/next/package-lock.json
@@ -4156,6 +4156,33 @@
         }
       }
     },
+    "express-session": {
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.16.2.tgz",
+      "integrity": "sha512-oy0sRsdw6n93E9wpCNWKRnSsxYnSDX9Dnr9mhZgqUEEorzcq5nshGYSZ4ZReHFhKQ80WI5iVUUSPW7u3GaKauw==",
+      "requires": {
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "~2.0.0",
+        "on-headers": "~1.0.2",
+        "parseurl": "~1.3.3",
+        "safe-buffer": "5.1.2",
+        "uid-safe": "~2.1.5"
+      },
+      "dependencies": {
+        "cookie": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+          "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
+        },
+        "depd": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+          "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
+        }
+      }
+    },
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -4471,8 +4498,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4490,13 +4516,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4509,18 +4533,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4623,8 +4644,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4634,7 +4654,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4647,20 +4666,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4677,7 +4693,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4750,8 +4765,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4761,7 +4775,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4837,8 +4850,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4868,7 +4880,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4886,7 +4897,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4925,13 +4935,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },
@@ -7510,6 +7518,11 @@
         "ee-first": "1.1.1"
       }
     },
+    "on-headers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA=="
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -8202,6 +8215,11 @@
         "discontinuous-range": "1.0.0",
         "ret": "~0.1.10"
       }
+    },
+    "random-bytes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
+      "integrity": "sha1-T2ih3Arli9P7lYSMMDJNt11kNgs="
     },
     "randombytes": {
       "version": "2.1.0",
@@ -10078,6 +10096,14 @@
           "dev": true,
           "optional": true
         }
+      }
+    },
+    "uid-safe": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
+      "integrity": "sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==",
+      "requires": {
+        "random-bytes": "~1.0.0"
       }
     },
     "uid2": {

--- a/next/package.json
+++ b/next/package.json
@@ -22,6 +22,7 @@
     "cookie-parser": "^1.4.4",
     "express": "4.17.x",
     "express-http-proxy": "^1.5.1",
+    "express-session": "^1.16.2",
     "graphql": "^14.0.2",
     "isomorphic-unfetch": "^3.0.0",
     "jsonwebtoken": "^8.5.1",

--- a/next/server-routes/auth.js
+++ b/next/server-routes/auth.js
@@ -71,13 +71,18 @@ passport.deserializeUser((user, done) => {
   done(null, user);
 });
 
-router.get(
-  '/google',
+router.get('/google', (req, res, next) => {
+  const ref = req.get('Referrer');
+  const url = new URL(ref);
+  // Chop off the origin to make sure we only try to do internal redirects
+  const redirectTo = url.href.substr(url.origin.length);
+  req.session.redirectTo = redirectTo;
+
   passport.authenticate('google', {
     scope: process.env.GOOGLE_AUTH_SCOPE,
     session: false
-  })
-);
+  })(req, res, next);
+});
 
 router.get(
   '/google/callback',
@@ -105,7 +110,7 @@ router.get(
       secured: process.env.NODE_ENV === 'production',
       maxAge: sessionTimeoutInSecs * 1000
     });
-    res.redirect('/');
+    res.redirect(req.session.redirectTo || '/');
   }
 );
 

--- a/next/server.js
+++ b/next/server.js
@@ -4,6 +4,7 @@ const proxy = require('express-http-proxy');
 
 const passport = require('passport');
 const cookieParser = require('cookie-parser');
+const session = require('express-session');
 
 const dev = process.env.NODE_ENV !== 'production';
 const app = next({ dev });
@@ -16,6 +17,11 @@ app
 
     server.use(cookieParser());
     server.use(passport.initialize());
+    server.use(
+      session({
+        secret: process.env.EXPRESS_SESSION_SECRET
+      })
+    );
 
     const auth = require('./server-routes/auth.js');
     server.use('/auth', auth);


### PR DESCRIPTION
Basically this:

- Serializes your deck-in-progress every time you make an edit and
tosses that value into session storage
- Whenever you load the deck builder page, we first check session
storage to see if anything is there. If something is there, it gets
loaded into the deck builder
- Logged out users now see a "log in to save your deck" type button
instead of the usual save when on the deck builder page.
- The BE will now attempt to return you to the same page you were on
after you log in.

This will require updates after we layer in deck editing capabilities.
E.g. we may want to ignore edits in session storage if the deck ID for
those edits doesn't match the deck you're trying to edit now.

I added sessions support to the express server that wraps our Next app.
This allows us to flash the redirect URL and get it back after bouncing
off the auth provider. If feels a little heavy handed to add sessions
just for this... I'm open to other suggestions. Other common solutions
include flashing to a cookie or DB storage - neither of those felt
particularly appealing either.