### PR TITLE
Fix power path export

### DIFF
--- a/next/components/deck.js
+++ b/next/components/deck.js
@@ -10,8 +10,8 @@ import { deckCardsQuery } from '../lib/deck-queries';
 const getDeckToExport = (deckCards, deckName, path = null, power = null) => {
   const deckToExport = initializeDeckBuilder();
   deckToExport.deckName = deckName;
-  deckToExport.deckPath = path ? path.name : '';
-  deckToExport.deckPower = power ? power.name : '';
+  deckToExport.deckPath = path ? { name: path.name } : {};
+  deckToExport.deckPower = power ? { name: power.name } : {};
   deckToExport.mainDeck = {
     ...deckCards
   };

--- a/next/lib/export-utils.js
+++ b/next/lib/export-utils.js
@@ -2,8 +2,8 @@ export const exportDeck = deckInProgress => {
   try {
     const exportMeta = [
       `name: ${deckInProgress.deckName}`,
-      `path: ${deckInProgress.deckPath.name}`,
-      `power: ${deckInProgress.deckPower.name}`,
+      `path: ${deckInProgress.deckPath.name || ''}`,
+      `power: ${deckInProgress.deckPower.name || ''}`,
       `coverart: ${deckInProgress.deckCoverArt}`
     ].join('\n');
 

--- a/next/lib/export-utils.test.js
+++ b/next/lib/export-utils.test.js
@@ -53,8 +53,8 @@ describe('Export utility methods', () => {
       const deckInProgress = initializeDeckBuilder();
       deckInProgress.deckName = 'my deck';
       deckInProgress.deckCoverArt = 'myself';
-      deckInProgress.deckPath = 'my path';
-      deckInProgress.deckPower = 'power rangers';
+      deckInProgress.deckPath = { name: 'my path' };
+      deckInProgress.deckPower = { name: 'power rangers' };
       deckInProgress.mainDeck = {
         1: { quantity: 1, card: { id: 1, name: 'card 1' } },
         2: { quantity: 2, card: { id: 2, name: 'card 2' } },
@@ -79,8 +79,8 @@ describe('Export utility methods', () => {
       const deckInProgress = initializeDeckBuilder();
       deckInProgress.deckName = 'my deck';
       deckInProgress.deckCoverArt = 'myself';
-      deckInProgress.deckPath = 'my path';
-      deckInProgress.deckPower = 'power rangers';
+      deckInProgress.deckPath = { name: 'my path' };
+      deckInProgress.deckPower = { name: 'power rangers' };
       deckInProgress.mainDeck = {
         1: { quantity: 1, card: { id: 1, name: 'card 1' } }
       };

--- a/next/lib/import-utils.test.js
+++ b/next/lib/import-utils.test.js
@@ -430,8 +430,8 @@ describe('Import utility methods', () => {
       expect(result.errors.length).toEqual(1);
       expect(result.deckCoverArt).toEqual('');
       expect(result.deckName).toEqual('');
-      expect(result.deckPath).toEqual('');
-      expect(result.deckPower).toEqual('');
+      expect(result.deckPath).toEqual({});
+      expect(result.deckPower).toEqual({});
       expect(Object.values(result.mainDeck).length).toEqual(0);
     });
   });


### PR DESCRIPTION
I went to fix some unit tests and found a couple of small bugs with export which should now be fixed.

- Power/path were showing up as "Power: undefined" in exports instead of being empty. This one the unit test caught for us!
- Power/path were always showing up as empty when exporting decks from the deck detail page