### PR TITLE
Swap back postgres creds for auth check

### DIFF
--- a/next/server-routes/auth.js
+++ b/next/server-routes/auth.js
@@ -6,9 +6,9 @@ const jwt = require('jsonwebtoken');
 const faker = require('faker');
 
 const client = new PgClient({
-  user: process.env.EXPRESS_PGUSER,
+  user: process.env.PGUSER,
   database: process.env.PGDATABASE,
-  password: process.env.EXPRESS_PGPASSWORD,
+  password: process.env.PGPASSWORD,
   host: process.env.PGHOST,
   port: process.env.PGPORT,
   ssl: process.env.PGSSL === 'yes'


### PR DESCRIPTION
Hey @evsheffield - I probably just had the wrong actual passwords in my secrets file but we should review these too just in case.

It looked like postgraphile was using the generic PGUSER/PGPASS creds and the auth checks were using the EXPRESS_* creds. I wasn't sure if there's a need for two separate creds or what the vision was for where we'd use which ones.