### PR TITLE
Add Hub after Mythgard in footer

### DIFF
--- a/next/components/footer.js
+++ b/next/components/footer.js
@@ -30,7 +30,7 @@ export default function Footer() {
           margin: 0 2px;
         }
       `}</style>
-      <span>&copy; {new Date().getFullYear()} Mythgard</span>
+      <span>&copy; {new Date().getFullYear()} Mythgard Hub</span>
       <a href={process.env.DISCORD_INVITE_URL}>Discord</a>
       <a href={`mailto:${process.env.EMAIL_MG_CONTACT}`}>General Contact</a>
       <a href={`mailto:${process.env.EMAIL_MG_SUPPORT}`}>Support</a>


### PR DESCRIPTION
Added the word 'Hub' after 'Mythgard' in the footer...

Did I dO the tHe thINg ritE? 

![image](https://user-images.githubusercontent.com/39966530/65397039-74fd0b80-dd7a-11e9-889d-a37ec24dd717.png)
