### PR TITLE
Fix import that was allowing card names with whitespace padding

### DIFF
--- a/next/.eslintrc.json
+++ b/next/.eslintrc.json
@@ -13,6 +13,7 @@
     "plugin:prettier/recommended"
   ],
   "rules": {
-    "react/react-in-jsx-scope": 0
+    "react/react-in-jsx-scope": 0,
+    "no-console": 0
   }
 }

--- a/scripts/import-cards.sql
+++ b/scripts/import-cards.sql
@@ -32,15 +32,15 @@ CREATE TEMPORARY TABLE t (
 insert into mythgard.card (id, name, rules, supertype, subtype, atk, def, mana, gem, rarity)
 select
   id
-  ,name
-  ,rules
+  ,trim(name)
+  ,trim(rules)
   ,string_to_array(trim(upper(supertype)), ',')::mythgard.cardType[]
-  ,subtype
+  ,trim(subtype)
   ,REGEXP_REPLACE(atk, '[^0-9]' ,'-1')::integer
   ,REGEXP_REPLACE(def, '[^0-9]' ,'-1')::integer
   ,REGEXP_REPLACE(manaCost, '[^0-9]' ,'-1')::integer
-  ,gemCost
-  ,UPPER(rarity)::mythgard.rarity
+  ,trim(gemCost)
+  ,UPPER(trim(rarity))::mythgard.rarity
   from t
 ON CONFLICT (id) DO UPDATE
 SET name = excluded.name

--- a/scripts/import-paths.sql
+++ b/scripts/import-paths.sql
@@ -9,8 +9,8 @@ CREATE TEMPORARY TABLE t (
 insert into mythgard.path (id, name, rules)
 select
   id,
-  name,
-  rules
+  trim(name),
+  trim(rules)
   from t
 ON CONFLICT (id) DO UPDATE
 SET name = excluded.name

--- a/scripts/import-powers.sql
+++ b/scripts/import-powers.sql
@@ -9,8 +9,8 @@ CREATE TEMPORARY TABLE t (
 insert into mythgard.power (id, name, rules)
 select
   id,
-  name,
-  rules
+  trim(name),
+  trim(rules)
   from t
 ON CONFLICT (id) DO UPDATE
 SET name = excluded.name


### PR DESCRIPTION
This padding was breaking import for `"Foul Harvest "`
I also am allowing console.log in eslint's config since that seems to be a convention we are allowing in our codebase.