### PR TITLE
Contact email in welcome banner

### DIFF
--- a/next/components/welcome-banner.js
+++ b/next/components/welcome-banner.js
@@ -59,7 +59,7 @@ export default function WelcomeBanner() {
 
       <a
         className="welcome-banner-link"
-        href={`mailto:${process.env.EMAIL_MG_SUPPORT}`}
+        href={`mailto:${process.env.EMAIL_MG_CONTACT}`}
       >
         Contact
       </a>


### PR DESCRIPTION
Changed email address in the welcome banner from EMAIL_MG_SUPPORT to EMAIL_MG_CONTACT

Addressing this topic on Trello: https://trello.com/c/a23OcbFm
