### PR TITLE
Deck list style

### DIFF
--- a/next/components/deck-card-table.js
+++ b/next/components/deck-card-table.js
@@ -39,8 +39,11 @@ export default function DeckCardsTable({ deck, deleteCard, onlyTable }) {
         .deck-card-link,
         .deck-card-link:hover,
         .deck-card-link:focus {
-          color: ${theme.fontColor};
+          color: ${theme.cardTableName};
           text-decoration: none;
+          text-transform: uppercase;
+          font-weight: 700;
+          font-size: 0.8em;
         }
       `}</style>
       {!onlyTable && (
@@ -70,7 +73,7 @@ export default function DeckCardsTable({ deck, deleteCard, onlyTable }) {
                     <a className="deck-card-link">{deckCard.card.name}</a>
                   </Link>
                 </td>
-                <td>x{deckCard.quantity}</td>
+                <td>&times;{deckCard.quantity}</td>
                 {deleteCard && (
                   <td
                     data-cy="deckDeleteCard"

--- a/next/components/import-deck.js
+++ b/next/components/import-deck.js
@@ -74,6 +74,7 @@ export default function ImportDeck({
         .import-deck-textarea {
           margin-top: 10px;
           margin-bottom: 10px;
+          max-width: 100%;
         }
       `}</style>
       <textarea


### PR DESCRIPTION
Some simple style adjustments for the deck list table, as well as a fix for the import textarea in the deck builder which was overflowing out of its column in Firefox.