### PR TITLE
Add Exo 2 Light for <P> tag, remove Vollkorn

### DIFF
--- a/next/components/layout.js
+++ b/next/components/layout.js
@@ -80,7 +80,7 @@ function Layout({ title, desc, children }) {
           <title>{title}</title>
           <meta name="description" key="desc" content={desc} />
           <link
-            href="https://fonts.googleapis.com/css?family=Exo+2:400,600,700&display=swap"
+            href="https://fonts.googleapis.com/css?family=Exo+2:300,300i,400,400i,600,600i,700,700i&display=swap"
             rel="stylesheet"
           />
         </Head>
@@ -104,8 +104,8 @@ function Layout({ title, desc, children }) {
           p {
             margin-bottom: 10px;
             line-height: 1.3em;
-            font-family: 'Vollkorn', serif;
-            font-weight: 400;
+            font-family: 'Exo 2', sans-serif;
+            font-weight: 300;
           }
 
           h1 {

--- a/next/pages/_app.js
+++ b/next/pages/_app.js
@@ -87,10 +87,6 @@ class MyApp extends App {
           <HooksApolloProvider client={apolloClient}>
             <Head>
               <link rel="icon" type="image/x-icon" href="/static/favicon.ico" />
-              <link
-                href="https://fonts.googleapis.com/css?family=Vollkorn:400,400i&display=swap"
-                rel="stylesheet"
-              ></link>
               <meta charSet="utf-8" />
               <meta
                 name="viewport"


### PR DESCRIPTION
- Removed Vollkorn typeface from styles (used specifically <p> tag for body copy)

- Added Exo 2 light (font-weight: 300) as a replacement

- Added Exo 2 italic styles to eliminate faux fonts

Checked in with Evan first to rule out any possible conflicts or unexpected ripple effects. 

For a preview of the intent, see: https://mythgard-hub.github.io/articles_template_new.html