### PR TITLE
Add Impel to Articles page

### DIFF
--- a/next/components/article-list.js
+++ b/next/components/article-list.js
@@ -39,6 +39,14 @@ function ArticleList({ max }) {
       description:
         'Control decks are in it for the long haul.  Traditionally, they play a patient, defensive game...',
       date: new Date('2019-09-22T17:24:18.280Z')
+    },
+    {
+      title: 'The Many Uses of Impel',
+      url:
+        'https://teamdgn.net/2019/09/27/the-many-uses-of-impel/',
+      description:
+        'Why Should You Use Impel? Some of you may think, “Wow, Impel doesn’t give me immediate value or combat benefits, movement can’t have that much impact!”  Well in Mythgard...',
+      date: new Date('2019-09-27T17:24:18.280Z')
     }
   ];
 

--- a/next/components/article-list.js
+++ b/next/components/article-list.js
@@ -42,8 +42,7 @@ function ArticleList({ max }) {
     },
     {
       title: 'The Many Uses of Impel',
-      url:
-        'https://teamdgn.net/2019/09/27/the-many-uses-of-impel/',
+      url: 'https://teamdgn.net/2019/09/27/the-many-uses-of-impel/',
       description:
         'Why Should You Use Impel? Some of you may think, “Wow, Impel doesn’t give me immediate value or combat benefits, movement can’t have that much impact!”  Well in Mythgard...',
       date: new Date('2019-09-27T17:24:18.280Z')


### PR DESCRIPTION
Implementing this request from Noah: 

`If we could also make a late inclusion to the articles page, another source has started producing content and diversifying that page a bit more would be splendid.
This article should be added to the articles page: https://teamdgn.net/2019/09/27/the-many-uses-of-impel/`