### PR TITLE
Artifact card detail

### DIFF
--- a/next/components/card.js
+++ b/next/components/card.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import GemCost from './gem-cost.js';
 import { imagePathMedium as getImagePath } from '../lib/card.js';
 import { getRarityImage } from '../constants/rarities.js';
-import { SUPERTYPE_IMAGES } from '../constants/supertypes.js';
+import { SUPERTYPES, SUPERTYPE_IMAGES } from '../constants/supertypes.js';
 
 const firstLetterUppercase = str => {
   return !str || str.charAt(0).toUpperCase() + str.slice(1).toLowerCase();
@@ -168,10 +168,16 @@ export default function Card({ card }) {
             </li>
             {(card.atk || card.def) && (
               <li className="card-detail">
-                <div className="card-detail-label">Attack/Health</div>
+                <div className="card-detail-label">
+                  {supertype === SUPERTYPES.artifact
+                    ? 'Durability'
+                    : 'Attack / Health'}
+                </div>
                 <hr />
                 <div className="card-detail-text">
-                  {card.atk}/{card.def}
+                  {supertype === SUPERTYPES.artifact
+                    ? card.def
+                    : `${card.atk}/${card.def}`}
                 </div>
               </li>
             )}

--- a/next/constants/supertypes.js
+++ b/next/constants/supertypes.js
@@ -4,7 +4,9 @@ export const SUPERTYPES = {
   minion: 'MINION',
   spell: 'SPELL',
   enchantment: 'ENCHANTMENT',
-  artifact: 'ARTIFACT'
+  artifact: 'ARTIFACT',
+  item: 'ITEM',
+  brand: 'BRAND'
 };
 
 export const SUPERTYPE_IMAGES = {

--- a/next/constants/supertypes.js
+++ b/next/constants/supertypes.js
@@ -1,5 +1,12 @@
 const cdn = `${process.env.MG_CDN}/filters/`;
 
+export const SUPERTYPES = {
+  minion: 'MINION',
+  spell: 'SPELL',
+  enchantment: 'ENCHANTMENT',
+  artifact: 'ARTIFACT'
+};
+
 export const SUPERTYPE_IMAGES = {
   minion: `${cdn}Filter-Icons_0000s_0004s_0000_minion.png`,
   spell: `${cdn}Filter-Icons_0000s_0004s_0001_spell.png`,


### PR DESCRIPTION
Small fix for the card detail page to display artifact durability as a single number instead of a truncated version of Attack/Health. https://trello.com/c/Yu19GMVR/21-remove-slash-preceding-number-for-attack-health-on-card-pages-for-artifacts