### PR TITLE
Change discord invite link

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -56,4 +56,4 @@ EMAIL_MG_EVENTS=Tournaments@mythgardhub.com
 EMAIL_MG_BUSINESS=Partnership@Mythgardhub.com
 
 
-DISCORD_INVITE_URL=https://discordapp.com/invite/frwc4Pp
+DISCORD_INVITE_URL=https://discord.gg/2erdzxj

--- a/.env.template
+++ b/.env.template
@@ -56,4 +56,4 @@ EMAIL_MG_EVENTS=Tournaments@mythgardhub.com
 EMAIL_MG_BUSINESS=Partnership@Mythgardhub.com
 
 
-DISCORD_INVITE_URL=https://discord.gg/2erdzxj
+DISCORD_INVITE_URL=https://discord.gg/RBX3zeG


### PR DESCRIPTION
Fix for two issues:

* Not sure what happened here, but it appears this branch was never merged or perhaps overwritten somehow? mythgard-hub/mythgard-hub: 2a7c33f (should have changed the link to https://discord.gg/2erdzxj - but current link on site is the old one)

* **_Regardless_**, the link that was reverted has expired anyway so - updating to resolve both issues: current Discord invite link should be: https://discord.gg/RBX3zeG