### PR TITLE
Deck builder edit path power

### DIFF
--- a/e2e/cypress/integration/deck-builder-page.js
+++ b/e2e/cypress/integration/deck-builder-page.js
@@ -25,8 +25,9 @@ describe('Deck builder page', () => {
   });
   it('should have a happy path', function() {
     cy.get('[data-cy="header"]').should('be.visible');
-    cy.get('[data-cy="importDeckTextarea"]').should('be.visible');
-    cy.get('[data-cy="importDeckButton"]').should('be.visible');
+    cy.get('[data-cy="goToImportMode"]').should('be.visible');
+    cy.get('[data-cy="importDeckButton"]').should('not.be.visible');
+    cy.get('[data-cy="deckBuilderActions"]').should('not.be.visible');
     cy.get(cardList).should('be.visible');
     cy.get(deckInProgress).should('be.visible');
     cy.get('[data-cy="factionFilters"]').should('be.visible');
@@ -39,6 +40,7 @@ describe('Deck builder page', () => {
       .click();
     cy.get(deckInProgress).should('be.visible');
     cy.get(deckCardRow).should('have.length', 2);
+    cy.get('[data-cy="deckBuilderActions"]').should('be.visible');
 
     // basic test - delete a card from the deck
     cy.get('[data-cy="deckDeleteCard"]:first').click();
@@ -143,6 +145,7 @@ describe('Deck builder page', () => {
       '1 ghūl'
     ].join('\n');
 
+    cy.get('[data-cy="goToImportMode"]').click();
     cy.get('[data-cy="importDeckTextarea"]').type(input);
     cy.get('[data-cy="importDeckButton"]').click();
 
@@ -163,11 +166,20 @@ describe('Deck builder page', () => {
       '2 Imp'
     ].join('\n');
 
+    // should be able to enter and exist import mode
+    cy.get('[data-cy="goToImportMode"]').click();
+    cy.get('[data-cy="importDeckTextarea"]').should('be.visible');
+    cy.get('[data-cy="deckBuilderActions"]').should('not.be.visible');
+    cy.get('[data-cy="cancelImportMode"]').click();
+    cy.get('[data-cy="importDeckTextarea"]').should('not.be.visible');
+
+    cy.get('[data-cy="goToImportMode"]').click();
     cy.get('[data-cy="importDeckTextarea"]').type(input);
     cy.get('[data-cy="importDeckButton"]').click();
     cy.get('[data-cy="exportDeckButton"]').click();
 
     cy.get('[data-cy="exportDeckSuccess"]').contains('Copied');
+    cy.get('[data-cy="deckBuilderActions"]').should('be.visible');
   });
 
   it('should clear filters', function() {

--- a/next/components/card-list.js
+++ b/next/components/card-list.js
@@ -17,6 +17,7 @@ export default function CardList({ onCardClick, cards, pageSize, options }) {
           list-style: none;
           display: flex;
           flex-wrap: wrap;
+          padding-left: 20px;
         }
         .cardListItem {
           margin-right: 17px;

--- a/next/components/card-search-form.js
+++ b/next/components/card-search-form.js
@@ -72,7 +72,7 @@ export default function CardSearchForm(props) {
         }
 
         .colLeft {
-          max-width: 535px;
+          max-width: 600px;
           flex-grow: 1;
         }
 

--- a/next/components/deck-builder-action-buttons.js
+++ b/next/components/deck-builder-action-buttons.js
@@ -1,0 +1,50 @@
+import PropTypes from 'prop-types';
+import DeckExport from '../components/deck-export';
+import SaveDeck from '../components/save-deck';
+
+export default function DeckBuilderActionButtons(props) {
+  const {
+    cardCount,
+    importMode,
+    deckId,
+    deckInProgress,
+    setDeckInProgress,
+    onClear
+  } = props;
+
+  if (!cardCount || importMode) return null;
+
+  return (
+    <div className="action-buttons" data-cy="deckBuilderActions">
+      <style jsx>{`
+        .action-buttons {
+          display: flex;
+          justify-content: space-between;
+        }
+        :global(.save-deck-container),
+        :global(.deck-export-container),
+        .clear-button-container {
+          width: 106px;
+        }
+      `}</style>
+      <SaveDeck
+        deckId={deckId}
+        deckInProgress={deckInProgress}
+        setDeckInProgress={setDeckInProgress}
+      />
+      <div className="clear-button-container">
+        <button onClick={onClear}>Clear</button>
+      </div>
+      <DeckExport deckInProgress={deckInProgress} />
+    </div>
+  );
+}
+
+DeckBuilderActionButtons.propTypes = {
+  deckId: PropTypes.number,
+  deckInProgress: PropTypes.object,
+  onClear: PropTypes.func,
+  setDeckInProgress: PropTypes.func,
+  importMode: PropTypes.bool,
+  cardCount: PropTypes.number
+};

--- a/next/components/deck-builder-card-display.js
+++ b/next/components/deck-builder-card-display.js
@@ -5,6 +5,7 @@ import ImportedDeckErrors from '../components/imported-deck-errors';
 import TabGroup from '../components/tab-group';
 import { addCardToDeck } from '../lib/deck-utils';
 import PropTypes from 'prop-types';
+import { DECK_BUILDER_TABS } from '../constants/deck';
 
 export default function DeckBuilderCardDisplay(props) {
   const {
@@ -53,8 +54,6 @@ export default function DeckBuilderCardDisplay(props) {
     });
   };
 
-  const tabLabels = ['Cards', 'Paths', 'Powers'];
-
   return (
     <div>
       <style jsx>{`
@@ -62,7 +61,12 @@ export default function DeckBuilderCardDisplay(props) {
           flex-grow: 1;
         }
       `}</style>
-      <TabGroup onChange={setTab} labels={tabLabels} name="cardsPathsPowers" />
+      <TabGroup
+        selectedLabel={currentTab}
+        onChange={setTab}
+        labels={DECK_BUILDER_TABS}
+        name="cardsPathsPowers"
+      />
       {currentTab === 'Cards' && (
         <div className="collection" data-cy="deckBuilderCollection">
           <SomeCards filters={cardFilters} onCardClick={onCollectionClick} />

--- a/next/components/deck-builder-sidebar.js
+++ b/next/components/deck-builder-sidebar.js
@@ -1,15 +1,16 @@
-import React, { useState } from 'react';
+import React, { useState, useContext } from 'react';
 import PropTypes from 'prop-types';
 import ImportDeck from '../components/import-deck';
 import DeckExport from '../components/deck-export';
 import DeckCardTable from '../components/deck-card-table';
-import EditDeckName from '../components/edit-deck-name';
 import SaveDeck from '../components/save-deck';
 import {
   initializeDeckBuilder,
   resetDeckBuilderSavedState,
   getCardCount
 } from '../lib/deck-utils';
+import { ThemeContext } from './theme-context';
+import DeckBuilderActionButtons from './deck-builder-action-buttons';
 
 export default function DeckBuilderSidebar(props) {
   const {
@@ -19,7 +20,9 @@ export default function DeckBuilderSidebar(props) {
     switchToCards,
     setTab
   } = props;
+  const theme = useContext(ThemeContext);
   const [mainDeckInput, setMainDeckInput] = useState('');
+  const [importMode, setImportMode] = useState(false);
 
   const updateDeckName = e => {
     setDeckInProgress({
@@ -70,8 +73,24 @@ export default function DeckBuilderSidebar(props) {
           font-weight: bold;
         }
         .build-deck-title {
-          text-transform: uppercase;
           text-align: center;
+          margin-bottom: 15px;
+          font-size: 18px;
+        }
+        .action-button-border {
+          margin-top: 18px;
+          margin-bottom: 10px;
+          margin-left: auto;
+          margin-right: auto;
+          width: 90%;
+          border: 0;
+          height: 1px;
+          background-image: linear-gradient(
+            to right,
+            ${theme.orangeSeparatorSecondaryColor},
+            ${theme.orangeSeparatorColor},
+            ${theme.orangeSeparatorSecondaryColor}
+          );
         }
 
         @media only screen and (max-width: 600px) {
@@ -80,37 +99,43 @@ export default function DeckBuilderSidebar(props) {
           }
         }
       `}</style>
-      <h2 className="build-deck-title">Import Deck from Mythgard</h2>
       <ImportDeck
         mainDeckInput={mainDeckInput}
         handleInputChange={e => {
           setMainDeckInput(e.target.value);
         }}
         updateImportedDeck={updateImportedDeck}
+        importMode={importMode}
+        setImportMode={setImportMode}
       />
-      <DeckExport deckInProgress={deckInProgress} />
-      <SaveDeck
+      <hr className="action-button-border" />
+      <DeckBuilderActionButtons
+        cardCount={cardCount}
+        importMode={importMode}
         deckId={deckId}
         deckInProgress={deckInProgress}
         setDeckInProgress={setDeckInProgress}
+        onClear={() => clearDeck(props.onClear)}
       />
-      <button onClick={() => clearDeck(props.onClear)}>Clear Deck</button>
-      <div className="deck-in-progress" data-cy="deckInProgress">
-        <h2 className="build-deck-title">- OR - BUILD YOUR DECK</h2>
-        <EditDeckName
-          deckName={deckInProgress.deckName}
-          onChange={updateDeckName}
-        />
-        <div className="card-count">
-          Cards: <span>{cardCount}</span>
+      {!importMode && !cardCount && (
+        <div className="build-deck-title">
+          - OR - Select a card to begin building
         </div>
-        <DeckCardTable
-          deck={deckInProgress}
-          deleteCard={deleteCardFromTable}
-          switchToCards={switchToCards}
-          setTab={setTab}
-        />
-      </div>
+      )}
+      {!importMode && (
+        <div className="deck-in-progress" data-cy="deckInProgress">
+          <div className="card-count">
+            Cards: <span>{cardCount}</span>
+          </div>
+          <DeckCardTable
+            updateDeckName={updateDeckName}
+            deck={deckInProgress}
+            deleteCard={deleteCardFromTable}
+            switchToCards={switchToCards}
+            setTab={setTab}
+          />
+        </div>
+      )}
     </div>
   );
 }

--- a/next/components/deck-builder-sidebar.js
+++ b/next/components/deck-builder-sidebar.js
@@ -12,7 +12,13 @@ import {
 } from '../lib/deck-utils';
 
 export default function DeckBuilderSidebar(props) {
-  const { deckId, deckInProgress, setDeckInProgress } = props;
+  const {
+    deckId,
+    deckInProgress,
+    setDeckInProgress,
+    switchToCards,
+    setTab
+  } = props;
   const [mainDeckInput, setMainDeckInput] = useState('');
 
   const updateDeckName = e => {
@@ -50,7 +56,7 @@ export default function DeckBuilderSidebar(props) {
     <div className="deck-builder-actions">
       <style jsx>{`
         .deck-builder-actions {
-          width: 35%;
+          width: 60%;
         }
         .deck-builder-actions button {
           margin-bottom: 10px;
@@ -98,7 +104,12 @@ export default function DeckBuilderSidebar(props) {
         <div className="card-count">
           Cards: <span>{cardCount}</span>
         </div>
-        <DeckCardTable deck={deckInProgress} deleteCard={deleteCardFromTable} />
+        <DeckCardTable
+          deck={deckInProgress}
+          deleteCard={deleteCardFromTable}
+          switchToCards={switchToCards}
+          setTab={setTab}
+        />
       </div>
     </div>
   );
@@ -127,5 +138,7 @@ DeckBuilderSidebar.propTypes = {
     errors: PropTypes.arrayOf(PropTypes.string)
   }),
   onClear: PropTypes.func,
-  setDeckInProgress: PropTypes.func
+  setDeckInProgress: PropTypes.func,
+  switchToCards: PropTypes.func,
+  setTab: PropTypes.func
 };

--- a/next/components/deck-builder-user.js
+++ b/next/components/deck-builder-user.js
@@ -1,0 +1,55 @@
+import { useContext } from 'react';
+import Link from 'next/link';
+import { ThemeContext } from './theme-context';
+import UserContext from '../components/user-context';
+
+export default function DeckBuilderUser() {
+  const theme = useContext(ThemeContext);
+  const { user } = useContext(UserContext);
+
+  const userElement = (
+    <Link href={user ? '/account' : '/auth/google'}>
+      <a data-cy="userLink" className="link">
+        {user?.username || 'Guest'}
+      </a>
+    </Link>
+  );
+
+  return (
+    <div className="deck-author">
+      <style jsx>{`
+        .deck-author {
+          display: flex;
+          justify-content: space-between;
+          margin: 10px 0;
+        }
+        .login-link,
+        .user-link {
+          text-decoration: none;
+          color: ${theme.fontColorAccent};
+        }
+        .login-link {
+          font-size: 14px;
+        }
+      `}</style>
+      <div>
+        by{' '}
+        <Link href={user ? '/account' : '/auth/google'}>
+          <a data-cy="userLink" className="user-link">
+            {user?.username || 'Guest'}
+          </a>
+        </Link>
+      </div>
+      {!user && (
+        <Link href="/auth/google">
+          <a
+            data-cy="loginToSave"
+            className="login-link call-to-action-chevron"
+          >
+            Login/Register
+          </a>
+        </Link>
+      )}
+    </div>
+  );
+}

--- a/next/components/deck-card-table-edit-meta.js
+++ b/next/components/deck-card-table-edit-meta.js
@@ -1,47 +1,43 @@
-import { useContext } from 'react';
 import PropTypes from 'prop-types';
 
 export default function DeckCardsTableEditMeta(props) {
   const { metaName, metaValue, onEditClick } = props;
 
   return (
-    metaValue || (
-      <div className="no-meta-value-selected-container">
-        <style jsx>{`
-          .no-meta-value-selected-container {
-            padding: 5px;
-            display: flex;
-            justify-content: space-between;
-          }
-          .edit-button {
-            padding: 0;
-            border: none;
-            text-transform: lowercase;
-            font-style: normal;
-            font-weight: normal;
-          }
-          .edit-button:before {
-            text-decoration: none;
-            content: '\u25b6';
-            margin-right: 3px;
-            font-size: 10px;
-          }
-          .no-meta-value {
-            text-transform: uppercase;
-          }
-        `}</style>
-        <div className="no-meta-value">No {metaName} selected</div>
-        <div>
-          <button
-            data-cy="editMetaValue"
-            className="edit-button"
-            onClick={onEditClick}
-          >
-            edit
-          </button>
-        </div>
+    <div className="no-meta-value-selected-container">
+      <style jsx>{`
+        .no-meta-value-selected-container {
+          display: flex;
+          justify-content: space-between;
+        }
+        .edit-button {
+          padding: 0;
+          border: none;
+          text-transform: lowercase;
+          font-style: normal;
+          font-weight: normal;
+        }
+        .edit-button:before {
+          text-decoration: none;
+          content: '\u25b6';
+          margin-right: 3px;
+          font-size: 10px;
+        }
+        .no-meta-value {
+          text-transform: uppercase;
+        }
+      `}</style>
+      {metaValue || <div className="no-meta-value">No {metaName} selected</div>}
+      <div>
+        <button
+          data-cy="editMetaValue"
+          className="edit-button"
+          onClick={onEditClick}
+        >
+          edit
+        </button>
       </div>
-    )
+    </div>
   );
 }
 

--- a/next/components/deck-card-table-edit-meta.js
+++ b/next/components/deck-card-table-edit-meta.js
@@ -1,0 +1,26 @@
+import { useContext } from 'react';
+import PropTypes from 'prop-types';
+
+export default function DeckCardsTableEditMeta({ metaName, metaValue }) {
+  return (
+    metaValue || (
+      <div className="no-meta-value-selected-container">
+        <style jsx>{`
+          .no-meta-value-selected-container {
+            display: flex;
+            justify-content: space-between;
+          }
+        `}</style>
+        <div>No {metaName} selected</div>
+        <div>
+          <button>edit</button>
+        </div>
+      </div>
+    )
+  );
+}
+
+DeckCardsTableEditMeta.propTypes = {
+  switchToCards: PropTypes.func,
+  setTab: PropTypes.func
+};

--- a/next/components/deck-card-table-edit-meta.js
+++ b/next/components/deck-card-table-edit-meta.js
@@ -1,19 +1,44 @@
 import { useContext } from 'react';
 import PropTypes from 'prop-types';
 
-export default function DeckCardsTableEditMeta({ metaName, metaValue }) {
+export default function DeckCardsTableEditMeta(props) {
+  const { metaName, metaValue, onEditClick } = props;
+
   return (
     metaValue || (
       <div className="no-meta-value-selected-container">
         <style jsx>{`
           .no-meta-value-selected-container {
+            padding: 5px;
             display: flex;
             justify-content: space-between;
           }
+          .edit-button {
+            padding: 0;
+            border: none;
+            text-transform: lowercase;
+            font-style: normal;
+            font-weight: normal;
+          }
+          .edit-button:before {
+            text-decoration: none;
+            content: '\u25b6';
+            margin-right: 3px;
+            font-size: 10px;
+          }
+          .no-meta-value {
+            text-transform: uppercase;
+          }
         `}</style>
-        <div>No {metaName} selected</div>
+        <div className="no-meta-value">No {metaName} selected</div>
         <div>
-          <button>edit</button>
+          <button
+            data-cy="editMetaValue"
+            className="edit-button"
+            onClick={onEditClick}
+          >
+            edit
+          </button>
         </div>
       </div>
     )
@@ -22,5 +47,6 @@ export default function DeckCardsTableEditMeta({ metaName, metaValue }) {
 
 DeckCardsTableEditMeta.propTypes = {
   switchToCards: PropTypes.func,
-  setTab: PropTypes.func
+  setTab: PropTypes.func,
+  onEditClick: PropTypes.func
 };

--- a/next/components/deck-card-table-edit-meta.js
+++ b/next/components/deck-card-table-edit-meta.js
@@ -17,12 +17,6 @@ export default function DeckCardsTableEditMeta(props) {
           font-style: normal;
           font-weight: normal;
         }
-        .edit-button:before {
-          text-decoration: none;
-          content: '\u25b6';
-          margin-right: 3px;
-          font-size: 10px;
-        }
         .no-meta-value {
           text-transform: uppercase;
         }
@@ -31,7 +25,7 @@ export default function DeckCardsTableEditMeta(props) {
       <div>
         <button
           data-cy="editMetaValue"
-          className="edit-button"
+          className="edit-button call-to-action-chevron"
           onClick={onEditClick}
         >
           edit

--- a/next/components/deck-card-table-row.js
+++ b/next/components/deck-card-table-row.js
@@ -15,7 +15,7 @@ export default function DeckCardsTableRow({ card, deleteCard, quantity }) {
     <tr key={card.id} data-cy="deckCardRow">
       <style jsx>{`
         td {
-          padding: 2px 5px 5px 5px;
+          padding: 6px;
           border: ${theme.cardTableBorder};
         }
         .deck-delete-card {

--- a/next/components/deck-card-table.js
+++ b/next/components/deck-card-table.js
@@ -5,7 +5,13 @@ import { FACTION_COLORS } from '../constants/factions';
 import DeckCardsTableRow from './deck-card-table-row';
 import DeckCardsTableEditMeta from './deck-card-table-edit-meta';
 
-export default function DeckCardsTable({ deck, deleteCard, onlyTable }) {
+export default function DeckCardsTable({
+  deck,
+  deleteCard,
+  onlyTable,
+  switchToCards,
+  setTab
+}) {
   const deckCards = deck && Object.values(deck.mainDeck);
   const colspan = deleteCard ? 3 : 2;
   const theme = useContext(ThemeContext);
@@ -102,6 +108,10 @@ export default function DeckCardsTable({ deck, deleteCard, onlyTable }) {
               <DeckCardsTableEditMeta
                 metaName="path"
                 metaValue={deck.deckPath?.name}
+                onEditClick={_ => {
+                  setTab('Paths');
+                  switchToCards();
+                }}
               />
             </td>
           </tr>
@@ -111,6 +121,10 @@ export default function DeckCardsTable({ deck, deleteCard, onlyTable }) {
               <DeckCardsTableEditMeta
                 metaName="power"
                 metaValue={deck.deckPower?.name}
+                onEditClick={_ => {
+                  setTab('Powers');
+                  switchToCards();
+                }}
               />
             </td>
           </tr>

--- a/next/components/deck-card-table.js
+++ b/next/components/deck-card-table.js
@@ -4,13 +4,16 @@ import { ThemeContext } from './theme-context';
 import { FACTION_COLORS } from '../constants/factions';
 import DeckCardsTableRow from './deck-card-table-row';
 import DeckCardsTableEditMeta from './deck-card-table-edit-meta';
+import EditDeckName from './edit-deck-name';
+import DeckBuilderUser from './deck-builder-user';
 
 export default function DeckCardsTable({
   deck,
   deleteCard,
   onlyTable,
   switchToCards,
-  setTab
+  setTab,
+  updateDeckName
 }) {
   const deckCards = deck && Object.values(deck.mainDeck);
   const colspan = deleteCard ? 3 : 2;
@@ -88,18 +91,18 @@ export default function DeckCardsTable({
           border-collapse: collapse;
           width: 100%;
         }
+        .deck-author {
+          margin: 10px 0;
+        }
         td {
           padding: 6px;
           border: ${theme.cardTableBorder};
         }
-        .deck-title {
-          font-size: 30px;
-          margin: 0 0 20px 5px;
-        }
       `}</style>
       {!onlyTable && (
-        <div className="deck-title">{deck.deckName || '[untitled]'}</div>
+        <EditDeckName deckName={deck.deckName} onChange={updateDeckName} />
       )}
+      {!onlyTable && <DeckBuilderUser />}
       <table className="deck-card-table" data-cy="deckCardTable">
         <tbody>
           <tr>
@@ -167,6 +170,7 @@ DeckCardsTable.propTypes = {
     }),
     errors: PropTypes.arrayOf(PropTypes.string),
     switchToCards: PropTypes.func,
-    setTab: PropTypes.func
+    setTab: PropTypes.func,
+    updateDeckName: PropTypes.func
   })
 };

--- a/next/components/deck-card-table.js
+++ b/next/components/deck-card-table.js
@@ -3,11 +3,10 @@ import PropTypes from 'prop-types';
 import { ThemeContext } from './theme-context';
 import { FACTION_COLORS } from '../constants/factions';
 import DeckCardsTableRow from './deck-card-table-row';
+import DeckCardsTableEditMeta from './deck-card-table-edit-meta';
 
 export default function DeckCardsTable({ deck, deleteCard, onlyTable }) {
   const deckCards = deck && Object.values(deck.mainDeck);
-  const power = (deck.deckPower && deck.deckPower.name) || '[no power]';
-  const path = (deck.deckPath && deck.deckPath.name) || '[no path]';
   const colspan = deleteCard ? 3 : 2;
   const theme = useContext(ThemeContext);
 
@@ -99,11 +98,21 @@ export default function DeckCardsTable({ deck, deleteCard, onlyTable }) {
         <tbody>
           <tr>
             <td colSpan={2}>Path</td>
-            <td colSpan={colspan}>{path}</td>
+            <td colSpan={colspan}>
+              <DeckCardsTableEditMeta
+                metaName="path"
+                metaValue={deck.deckPath?.name}
+              />
+            </td>
           </tr>
           <tr>
             <td colSpan={2}>Power</td>
-            <td colSpan={colspan}>{power}</td>
+            <td colSpan={colspan}>
+              <DeckCardsTableEditMeta
+                metaName="power"
+                metaValue={deck.deckPower?.name}
+              />
+            </td>
           </tr>
           {sortedCards.map((deckCard, i) => (
             <DeckCardsTableRow
@@ -142,6 +151,8 @@ DeckCardsTable.propTypes = {
         gem: PropTypes.number
       })
     }),
-    errors: PropTypes.arrayOf(PropTypes.string)
+    errors: PropTypes.arrayOf(PropTypes.string),
+    switchToCards: PropTypes.func,
+    setTab: PropTypes.func
   })
 };

--- a/next/components/deck-card-table.js
+++ b/next/components/deck-card-table.js
@@ -89,7 +89,7 @@ export default function DeckCardsTable({
           width: 100%;
         }
         td {
-          padding: 2px 5px 5px 5px;
+          padding: 6px;
           border: ${theme.cardTableBorder};
         }
         .deck-title {

--- a/next/components/edit-deck-name.js
+++ b/next/components/edit-deck-name.js
@@ -1,19 +1,36 @@
-import React from 'react';
+import { useContext } from 'react';
 import PropTypes from 'prop-types';
-import SearchFormText from './search-form-text.js';
+import { ThemeContext } from './theme-context';
 
 export default function EditDeckName(props) {
   const { deckName, onChange } = props;
+  const theme = useContext(ThemeContext);
 
   return (
-    <SearchFormText
-      label="Deck Name"
-      value={deckName}
-      name="text"
-      cyName="deckTitle"
-      onChange={onChange}
-      placeholder="Enter a name..."
-    />
+    <div className="deck-name-container">
+      <style jsx>{`
+        input {
+          width: 100%;
+          background-color: transparent;
+          border: ${theme.inputBorder};
+          border-radius: 10px;
+          font-size: 20px;
+          font-family: ${theme.fontFamily};
+          padding: 5px 5px 7px 5px;
+          color: ${theme.fontColor};
+        }
+        input::placeholder {
+          padding: 5px 5px 7px 5px;
+          color: ${theme.fontColor};
+        }
+      `}</style>
+      <input
+        value={deckName}
+        data-cy="deckTitle"
+        onChange={onChange}
+        placeholder="Untitled"
+      />
+    </div>
   );
 }
 

--- a/next/components/gem-dot.js
+++ b/next/components/gem-dot.js
@@ -40,7 +40,7 @@ export default function GemDot({ gems }) {
     <span>
       <style jsx>{`
         span {
-          font-size: 24px;
+          font-size: 15px;
         }
       `}</style>
       {gemElements}

--- a/next/components/import-deck.js
+++ b/next/components/import-deck.js
@@ -77,7 +77,7 @@ export default function ImportDeck({
 
   const onClick = () => {
     const confirmation = confirm(
-      'Are you sure you want to import? This will replace the current deck.'
+      'Importing will overwrite deck in progress. Continue?'
     );
 
     if (confirmation) {

--- a/next/components/import-deck.js
+++ b/next/components/import-deck.js
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import PropTypes from 'prop-types';
 import { useQuery } from 'react-apollo-hooks';
 
@@ -28,7 +29,9 @@ const handleImport = (
 export default function ImportDeck({
   mainDeckInput,
   handleInputChange,
-  updateImportedDeck
+  updateImportedDeck,
+  importMode,
+  setImportMode
 }) {
   const {
     loading: cardsLoading,
@@ -43,6 +46,21 @@ export default function ImportDeck({
     error: powerError,
     data: powerData
   } = useQuery(allPowersQuery);
+
+  if (!importMode) {
+    return (
+      <div>
+        <style jsx>{`
+          div {
+            margin-top: 20px;
+          }
+        `}</style>
+        <button onClick={e => setImportMode(true)} data-cy="goToImportMode">
+          Import
+        </button>
+      </div>
+    );
+  }
 
   const error = cardsError || pathError || powerError;
   if (error) return <ErrorMessage message={error.message} />;
@@ -64,35 +82,44 @@ export default function ImportDeck({
 
     if (confirmation) {
       handleImport(mainDeckInput, updateImportedDeck, cards, paths, powers);
+      setImportMode(false);
     }
   };
 
   return (
     <div className="import-deck-container">
       <style jsx>{`
-        .import-deck-container {
+        .import-button {
+          margin-top: 20px;
           margin-bottom: 10px;
         }
         .import-deck-textarea {
-          margin-top: 10px;
+          margin-top: 30px;
           margin-bottom: 10px;
           max-width: 100%;
           width: 100%;
         }
       `}</style>
+      <button
+        onClick={onClick}
+        data-cy="importDeckButton"
+        className="import-button"
+      >
+        Import Decklist
+      </button>
+      <button onClick={_ => setImportMode(false)} data-cy="cancelImportMode">
+        Cancel
+      </button>
       <textarea
         className="import-deck-textarea"
         data-cy="importDeckTextarea"
         cols="39"
-        rows="2"
+        rows="20"
         value={mainDeckInput}
         name="mainDeckInput"
         onChange={handleInputChange}
         placeholder="Paste deck from Mythgard..."
       />
-      <button onClick={onClick} data-cy="importDeckButton">
-        Import
-      </button>
     </div>
   );
 }
@@ -113,5 +140,7 @@ ImportDeck.propTypes = {
     })
   }),
   handleInputChange: PropTypes.func,
-  updateImportedDeck: PropTypes.func
+  updateImportedDeck: PropTypes.func,
+  importMode: PropTypes.bool,
+  setImportMode: PropTypes.func
 };

--- a/next/components/layout.js
+++ b/next/components/layout.js
@@ -16,7 +16,7 @@ function Layout({ title, desc, children }) {
       <div className="container">
         <style jsx>{`
           .container {
-            padding: 0 43px;
+            padding: 0 20px;
             border-left: ${theme.border};
             border-right: ${theme.border};
             font-family: ${theme.fontFamily};

--- a/next/components/layout.js
+++ b/next/components/layout.js
@@ -352,6 +352,13 @@ function Layout({ title, desc, image, router, children }) {
             margin-bottom: 25px;
           }
 
+          .call-to-action-chevron:before {
+            text-decoration: none;
+            content: '\u25b6';
+            margin-right: 3px;
+            font-size: 10px;
+          }
+
           .external-link::after {
             background-image: url('https://cdn.mythgardhub.com/icons/newWindow.svg');
             background-size: 12px 12px;

--- a/next/components/save-deck.js
+++ b/next/components/save-deck.js
@@ -42,7 +42,7 @@ export default function SaveDeck({
     saveButton = (
       <Link href="/auth/google">
         <a className="button" data-cy="saveDeck">
-          Login to Save
+          Save
         </a>
       </Link>
     );

--- a/next/components/tab-group.js
+++ b/next/components/tab-group.js
@@ -1,69 +1,64 @@
-import React, { useState, useEffect } from 'react';
+import { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { ThemeContext } from './theme-context';
 
-function TabGroup({ onChange, name, labels }) {
-  const [selectedLabel, setLabel] = useState(labels[0]);
-
-  useEffect(() => onChange(selectedLabel));
+function TabGroup({ name, labels, selectedLabel, onChange }) {
+  const theme = useContext(ThemeContext);
 
   return (
-    <ThemeContext.Consumer>
-      {theme => (
-        <div className="mg-tab-group" data-cy={`tabs_${name}`}>
-          <style jsx>{`
-            .mg-tab-group {
-              display: flex;
-              flex-wrap: nowrap;
-              font-size: 11px;
-            }
-            .tab {
-              border: ${theme.tabBorder};
-              border-bottom-left-radius: 0px;
-              border-bottom-right-radius: 0px;
-              color: ${theme.tabColor};
-              min-width: 100px;
-              padding: 0 5px;
-              text-align: center;
-              height: 30px;
-            }
-            .tab.selected {
-              border-bottom: none;
-            }
-            .tab:hover {
-              background-color: ${theme.backgroundLight};
-            }
-            .tab-spacer {
-              border-bottom: ${theme.tabBorder};
-              min-width: 15px;
-            }
-            .tab-spacer:last-of-type {
-              flex-grow: 1;
-            }
-          `}</style>
-          <div className="tab-spacer"></div>
-          {labels.map((label, i) => {
-            const selectedClass = label == selectedLabel ? 'selected' : '';
-            return (
-              <React.Fragment key={i}>
-                <button
-                  className={`tab reset-button ${selectedClass}`}
-                  onClick={() => setLabel(label)}
-                >
-                  {label}
-                </button>
-                <div className="tab-spacer"></div>
-              </React.Fragment>
-            );
-          })}
-          <div className="tab-spacer"></div>
-        </div>
-      )}
-    </ThemeContext.Consumer>
+    <div className="mg-tab-group" data-cy={`tabs_${name}`}>
+      <style jsx>{`
+        .mg-tab-group {
+          display: flex;
+          flex-wrap: nowrap;
+          font-size: 11px;
+        }
+        .tab {
+          border: ${theme.tabBorder};
+          border-bottom-left-radius: 0px;
+          border-bottom-right-radius: 0px;
+          color: ${theme.tabColor};
+          min-width: 100px;
+          padding: 0 5px;
+          text-align: center;
+          height: 30px;
+        }
+        .tab.selected {
+          border-bottom: none;
+        }
+        .tab:hover {
+          background-color: ${theme.backgroundLight};
+        }
+        .tab-spacer {
+          border-bottom: ${theme.tabBorder};
+          min-width: 15px;
+        }
+        .tab-spacer:last-of-type {
+          flex-grow: 1;
+        }
+      `}</style>
+      <div className="tab-spacer"></div>
+      {labels.map((label, i) => {
+        const selectedClass = label == selectedLabel ? 'selected' : '';
+        return (
+          <React.Fragment key={i}>
+            <button
+              className={`tab reset-button ${selectedClass}`}
+              onClick={() => onChange(label)}
+            >
+              {label}
+            </button>
+            <div className="tab-spacer"></div>
+          </React.Fragment>
+        );
+      })}
+      <div className="tab-spacer"></div>
+    </div>
   );
 }
 
 TabGroup.propTypes = {
+  selectedLabel: PropTypes.string.isRequired,
   onChange: PropTypes.func.isRequired,
   name: PropTypes.string.isRequired,
   labels: PropTypes.array.isRequired

--- a/next/components/theme-context.js
+++ b/next/components/theme-context.js
@@ -42,6 +42,8 @@ export const themes = {
     footerLinkColor: mgColors.orange,
     footerTextColor: mgColors.mediumLighterGray,
     selectedPageColor: mgColors.blue,
+    orangeSeparatorColor: mgColors.orange,
+    orangeSeparatorSecondaryColor: mgColors.blackPearl,
     blueFactionColor: mgColors.blue,
     redFactionColor: mgColors.red,
     yellowFactionColor: mgColors.yellow,

--- a/next/components/welcome-banner.js
+++ b/next/components/welcome-banner.js
@@ -25,11 +25,6 @@ export default function WelcomeBanner() {
           align-items: center;
         }
 
-        .welcome-banner-link:before {
-          content: '\u25b6';
-          margin-right: 3px;
-        }
-
         .welcome-banner-link-username:before {
           content: none;
         }
@@ -71,7 +66,7 @@ export default function WelcomeBanner() {
       `}</style>
 
       <a
-        className="welcome-banner-link"
+        className="welcome-banner-link call-to-action-chevron"
         href={`mailto:${process.env.EMAIL_MG_CONTACT}`}
       >
         Contact
@@ -84,7 +79,10 @@ export default function WelcomeBanner() {
       <span className="spacer"></span>
 
       {!user && (
-        <a href="/auth/google" className="welcome-banner-link">
+        <a
+          href="/auth/google"
+          className="welcome-banner-link call-to-action-chevron"
+        >
           Login/Register
         </a>
       )}

--- a/next/constants/deck.js
+++ b/next/constants/deck.js
@@ -15,3 +15,5 @@ export const DECK_SIZES = {
   MIN: 40,
   MAX: 200
 };
+
+export const DECK_BUILDER_TABS = ['Cards', 'Paths', 'Powers'];

--- a/next/lib/deck-utils.js
+++ b/next/lib/deck-utils.js
@@ -6,7 +6,7 @@ import { RARITY_MAX_CARDS } from '../constants/rarities';
 
 export const initializeDeckBuilder = () => {
   return {
-    deckName: '',
+    deckName: 'Untitled',
     deckPath: {},
     deckPower: {},
     deckCoverArt: '',

--- a/next/lib/export-utils.test.js
+++ b/next/lib/export-utils.test.js
@@ -13,7 +13,7 @@ describe('Export utility methods', () => {
 
       const result = exportDeck(deckInProgress);
       const expected = [
-        'name: ',
+        'name: Untitled',
         'path: ',
         'power: ',
         'coverart: ',

--- a/next/lib/import-utils.test.js
+++ b/next/lib/import-utils.test.js
@@ -558,7 +558,7 @@ describe('Import utility methods', () => {
 
       expect(result.errors.length).toEqual(1);
       expect(result.deckCoverArt).toEqual('');
-      expect(result.deckName).toEqual('');
+      expect(result.deckName).toEqual('Untitled');
       expect(result.deckPath).toEqual({});
       expect(result.deckPower).toEqual({});
       expect(Object.values(result.mainDeck).length).toEqual(0);

--- a/next/lib/string-utils.js
+++ b/next/lib/string-utils.js
@@ -8,7 +8,7 @@ export const firstLetterUppercase = str => {
 
 export const ordinalized = i => {
   try {
-    if (!i) return '';
+    if (!i && i !=== 0) return '';
 
     const j = i % 10,
       k = i % 100;

--- a/next/lib/string-utils.js
+++ b/next/lib/string-utils.js
@@ -6,9 +6,17 @@ export const firstLetterUppercase = str => {
   }
 };
 
+function isInt(value) {
+  return (
+    !isNaN(value) &&
+    parseInt(Number(value)) == value &&
+    !isNaN(parseInt(value, 10))
+  );
+}
+
 export const ordinalized = i => {
   try {
-    if (!i && i !== 0) return '';
+    if (!isInt(i)) return '';
 
     const j = i % 10,
       k = i % 100;

--- a/next/lib/string-utils.js
+++ b/next/lib/string-utils.js
@@ -8,6 +8,8 @@ export const firstLetterUppercase = str => {
 
 export const ordinalized = i => {
   try {
+    if (!i) return '';
+
     const j = i % 10,
       k = i % 100;
 

--- a/next/lib/string-utils.js
+++ b/next/lib/string-utils.js
@@ -5,3 +5,25 @@ export const firstLetterUppercase = str => {
     return '';
   }
 };
+
+export const ordinalized = i => {
+  try {
+    const j = i % 10,
+      k = i % 100;
+
+    if (j == 1 && k != 11) {
+      return i + 'st';
+    }
+
+    if (j == 2 && k != 12) {
+      return i + 'nd';
+    }
+
+    if (j == 3 && k != 13) {
+      return i + 'rd';
+    }
+    return i + 'th';
+  } catch (e) {
+    return '';
+  }
+};

--- a/next/lib/string-utils.js
+++ b/next/lib/string-utils.js
@@ -8,7 +8,7 @@ export const firstLetterUppercase = str => {
 
 export const ordinalized = i => {
   try {
-    if (!i && i !=== 0) return '';
+    if (!i && i !== 0) return '';
 
     const j = i % 10,
       k = i % 100;

--- a/next/lib/string-utils.test.js
+++ b/next/lib/string-utils.test.js
@@ -5,6 +5,7 @@ describe('String utility methods', () => {
     it('Should return a number ordinalized', function() {
       expect(ordinalized(0)).toBe('0th');
       expect(ordinalized(1)).toBe('1st');
+      expect(ordinalized('1')).toBe('1st');
       expect(ordinalized(2)).toBe('2nd');
       expect(ordinalized(3)).toBe('3rd');
       expect(ordinalized(4)).toBe('4th');
@@ -15,7 +16,6 @@ describe('String utility methods', () => {
     });
 
     it('Should handle nonsense data gracefully', function() {
-      expect(ordinalized('1')).toBe('');
       expect(ordinalized([])).toBe('');
       expect(ordinalized()).toBe('');
       expect(ordinalized([1, 1])).toBe('');

--- a/next/lib/string-utils.test.js
+++ b/next/lib/string-utils.test.js
@@ -1,0 +1,26 @@
+import { ordinalized } from './string-utils';
+
+describe('String utility methods', () => {
+  describe('Test ordinalized', () => {
+    it('Should return a number ordinalized', function() {
+      expect(ordinalized(0)).toBe('0th');
+      expect(ordinalized(1)).toBe('1st');
+      expect(ordinalized(2)).toBe('2nd');
+      expect(ordinalized(3)).toBe('3rd');
+      expect(ordinalized(4)).toBe('4th');
+      expect(ordinalized(5)).toBe('5th');
+      expect(ordinalized(10)).toBe('10th');
+      expect(ordinalized(50)).toBe('50th');
+      expect(ordinalized(500)).toBe('500th');
+    });
+
+    it('Should handle nonsense data gracefully', function() {
+      expect(ordinalized('1')).toBe('');
+      expect(ordinalized([])).toBe('');
+      expect(ordinalized()).toBe('');
+      expect(ordinalized([1, 1])).toBe('');
+      expect(ordinalized({ a: 'a' })).toBe('');
+      expect(ordinalized(null)).toBe('');
+    });
+  });
+});

--- a/next/pages/deck-builder.js
+++ b/next/pages/deck-builder.js
@@ -19,6 +19,7 @@ import DeckBuilderCardDisplay from '../components/deck-builder-card-display';
 import ErrorMessage from '../components/error-message';
 import PropTypes from 'prop-types';
 import { useApolloClient } from 'react-apollo-hooks';
+import { DECK_BUILDER_TABS } from '../constants/deck';
 
 const initFilters = {
   cardSearchText: '',
@@ -130,7 +131,7 @@ function DeckBuilderPage({ deckId, useSessionStorage }) {
   const [cardManaCosts, setCardManaCosts] = useState(initFilters.cardManaCosts);
   const [supertypes, setSupertypes] = useState(initFilters.supertypes);
   const [factions, setFactions] = useState(initFilters.factions);
-  const [currentTab, setTab] = useState('');
+  const [currentTab, setTab] = useState(DECK_BUILDER_TABS[0]);
   const [viewFilters, setViewFilters] = useState(false);
   const [isError, setIsError] = useState(false);
   const [editingExisting, setEditingExisting] = useState(false);

--- a/next/pages/deck-builder.js
+++ b/next/pages/deck-builder.js
@@ -53,7 +53,6 @@ const userWantsToDiscardChanges = () => confirm(clearSessionStorageMsg);
 // previously worked on decks is not run during an SSR.
 const loadExistingDeck = (
   deckId,
-  deckInProgress,
   setDeckInProgress,
   setIsError,
   client,
@@ -174,7 +173,7 @@ function DeckBuilderPage({ deckId, useSessionStorage }) {
       <style jsx>{`
         .deck-builder-card-selection {
           width: 100%;
-          padding-right: 25px;
+          padding-right: 15px;
         }
         .deck-builder-panels {
           display: flex;
@@ -254,6 +253,8 @@ function DeckBuilderPage({ deckId, useSessionStorage }) {
             )}
           </div>
           <DeckBuilderSidebar
+            switchToCards={_ => setViewFilters(false)}
+            setTab={setTab}
             deckId={deckId}
             deckInProgress={deckInProgress}
             setDeckInProgress={setDeckInProgress}

--- a/next/pages/deck-builder.js
+++ b/next/pages/deck-builder.js
@@ -54,6 +54,7 @@ const userWantsToDiscardChanges = () => confirm(clearSessionStorageMsg);
 // previously worked on decks is not run during an SSR.
 const loadExistingDeck = (
   deckId,
+  deckInProgress,
   setDeckInProgress,
   setIsError,
   client,

--- a/next/pages/event.js
+++ b/next/pages/event.js
@@ -10,106 +10,112 @@ import FactionsIndicator from '../components/factions-indicator.js';
 import EssenceIndicator from '../components/essence-indicator.js';
 import { dbDateToDisplayDate } from '../lib/time.js';
 import { tournamentWithResultsQuery as tourneyQuery } from '../lib/tournament-queries.js';
+import { ordinalized } from '../lib/string-utils';
 import Router from 'next/router';
-
-// Copied from stackoverflow, so untested.
-function ordinalized(i) {
-  const j = i % 10,
-    k = i % 100;
-  if (j == 1 && k != 11) {
-    return i + 'st';
-  }
-  if (j == 2 && k != 12) {
-    return i + 'nd';
-  }
-  if (j == 3 && k != 13) {
-    return i + 'rd';
-  }
-  return i + 'th';
-}
 
 export default withRouter(({ router }) => {
   const { error, loading, data } = useQuery(tourneyQuery, {
     variables: { id: parseInt(router.query.id, 10) }
   });
 
+  let pageTitle = 'Mythgard Hub | Event Results';
+  let tournamentDecksTable = null;
+
   if (error) {
-    return <ErrorMessage message={error.message} />;
+    tournamentDecksTable = <ErrorMessage message={error.message} />;
   } else if (loading) {
-    return <div>Loading...</div>;
+    tournamentDecksTable = <div>Loading...</div>;
+  } else {
+    const { tournament } = data;
+
+    if (!tournament) {
+      Router.replace('/events');
+      return null;
+    }
+
+    const tournamentDecks =
+      (tournament.tournamentDecks && tournament.tournamentDecks.nodes) || [];
+
+    pageTitle = `Mythgard Hub | Results for ${tournament.name}`;
+
+    tournamentDecksTable =
+      !tournamentDecks || !tournamentDecks.length ? (
+        'No decks found'
+      ) : (
+        <React.Fragment>
+          <a
+            className="external-link accent bold tourneyLink"
+            data-cy="tourneyLink"
+            href={tournament.url}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Tournament Details
+          </a>
+          <h2 data-cy="tourneyName">{tournament.name}</h2>
+          <h3 className="subtle">{dbDateToDisplayDate(tournament.date)}</h3>
+          <h1>Results &amp; Decks</h1>
+          <LargeTable>
+            <style jsx>{`
+              .pilotedBy {
+                font-weight: 300;
+              }
+
+              .nameCellInner {
+                display: inline-block;
+                text-align: left;
+              }
+
+              tr > td {
+                text-align: left;
+              }
+
+              tr > td:first-of-type {
+                max-width: 25px;
+              }
+            `}</style>
+            <tbody>
+              {tournamentDecks
+                .sort((a, b) => {
+                  return a.rank > b.rank;
+                })
+                .map((tourneyDeck, index) => {
+                  const { deck } = tourneyDeck;
+                  const deckPreview = deck.deckPreviews.nodes[0];
+                  const classNames = index % 2 ? 'zebraRow' : '';
+                  return (
+                    <tr
+                      key={index}
+                      className={classNames}
+                      data-cy="deckListItem"
+                    >
+                      <td>{ordinalized(tourneyDeck.rank)}</td>
+                      <td className="nameCell" data-cy="tourneyTop8Name">
+                        <span className="nameCellInner">
+                          <Link href={`/deck?id=${deck.id}`}>
+                            <a data-cy="tourneyDeckLink">
+                              <b>{deck.name}</b>
+                            </a>
+                          </Link>{' '}
+                          <br />
+                          <span className="pilotedBy">piloted by</span>{' '}
+                          <span className="accent">{tourneyDeck.pilot}</span>
+                        </span>
+                      </td>
+                      <td>
+                        <FactionsIndicator factions={deckPreview.factions} />
+                      </td>
+                      <td>
+                        <EssenceIndicator essence={deckPreview.essenceCost} />
+                      </td>
+                    </tr>
+                  );
+                })}
+            </tbody>
+          </LargeTable>
+        </React.Fragment>
+      );
   }
-
-  const { tournament } = data;
-
-  if (!tournament) {
-    Router.replace('/events');
-    return null;
-  }
-
-  const tournamentDecks =
-    (tournament.tournamentDecks && tournament.tournamentDecks.nodes) || [];
-
-  const pageTitle = `Mythgard Hub | Results for ${tournament.name}`;
-
-  const tournamentDecksTable =
-    !tournamentDecks || !tournamentDecks.length ? (
-      'No decks found'
-    ) : (
-      <LargeTable>
-        <style jsx>{`
-          .pilotedBy {
-            font-weight: 300;
-          }
-
-          .nameCellInner {
-            display: inline-block;
-            text-align: left;
-          }
-
-          tr > td {
-            text-align: left;
-          }
-
-          tr > td:first-of-type {
-            max-width: 25px;
-          }
-        `}</style>
-        <tbody>
-          {tournamentDecks
-            .sort((a, b) => {
-              return a.rank > b.rank;
-            })
-            .map((tourneyDeck, index) => {
-              const { deck } = tourneyDeck;
-              const deckPreview = deck.deckPreviews.nodes[0];
-              const classNames = index % 2 ? 'zebraRow' : '';
-              return (
-                <tr key={index} className={classNames} data-cy="deckListItem">
-                  <td>{ordinalized(tourneyDeck.rank)}</td>
-                  <td className="nameCell" data-cy="tourneyTop8Name">
-                    <span className="nameCellInner">
-                      <Link href={`/deck?id=${deck.id}`}>
-                        <a data-cy="tourneyDeckLink">
-                          <b>{deck.name}</b>
-                        </a>
-                      </Link>{' '}
-                      <br />
-                      <span className="pilotedBy">piloted by</span>{' '}
-                      <span className="accent">{tourneyDeck.pilot}</span>
-                    </span>
-                  </td>
-                  <td>
-                    <FactionsIndicator factions={deckPreview.factions} />
-                  </td>
-                  <td>
-                    <EssenceIndicator essence={deckPreview.essenceCost} />
-                  </td>
-                </tr>
-              );
-            })}
-        </tbody>
-      </LargeTable>
-    );
 
   return (
     <Layout title={pageTitle} desc="Winners and decklists">
@@ -139,18 +145,6 @@ export default withRouter(({ router }) => {
           <PageBanner image={PageBanner.IMG_EVENTS}>Events</PageBanner>
         </a>
       </Link>
-      <a
-        className="external-link accent bold tourneyLink"
-        data-cy="tourneyLink"
-        href={tournament.url}
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        Tournament Details
-      </a>
-      <h2 data-cy="tourneyName">{tournament.name}</h2>
-      <h3 className="subtle">{dbDateToDisplayDate(tournament.date)}</h3>
-      <h1>Results &amp; Decks</h1>
       {tournamentDecksTable}
     </Layout>
   );


### PR DESCRIPTION
PR 1 for the deck builder refactoring

- First step in the big deck builder refactor - adding an edit button in the path and power rows.
- This did mean that `tab-group` can no longer maintain its own state regarding which tab is selected... it's gotta come from above.
- `tab-group` is also using the context hook.
- The table needed to be a bit bigger to look good, so refactored the spaces a bit to look more like the template (the margins are more narrow there so there is space for 3 columns of cards). The rest of the pages look okay on desktop and the same on mobile.
- Events page: moved the loading and error to be inside the layout.
- There are no new tests on purpose, since the final stage might be quite different in the end.

This is the big change:
![image](https://user-images.githubusercontent.com/4063797/68093624-9ebf4d00-fe65-11e9-9959-630f9839fa1d.png)

This seems like a lot of refactoring but it's only step 1. Sorry if it has too much!