### PR TITLE
Deck builder edit name + show user

### DIFF
--- a/e2e/cypress/integration/deck-builder-page.js
+++ b/e2e/cypress/integration/deck-builder-page.js
@@ -25,8 +25,9 @@ describe('Deck builder page', () => {
   });
   it('should have a happy path', function() {
     cy.get('[data-cy="header"]').should('be.visible');
-    cy.get('[data-cy="importDeckTextarea"]').should('be.visible');
-    cy.get('[data-cy="importDeckButton"]').should('be.visible');
+    cy.get('[data-cy="goToImportMode"]').should('be.visible');
+    cy.get('[data-cy="importDeckButton"]').should('not.be.visible');
+    cy.get('[data-cy="deckBuilderActions"]').should('not.be.visible');
     cy.get(cardList).should('be.visible');
     cy.get(deckInProgress).should('be.visible');
     cy.get('[data-cy="factionFilters"]').should('be.visible');
@@ -39,6 +40,7 @@ describe('Deck builder page', () => {
       .click();
     cy.get(deckInProgress).should('be.visible');
     cy.get(deckCardRow).should('have.length', 2);
+    cy.get('[data-cy="deckBuilderActions"]').should('be.visible');
 
     // basic test - delete a card from the deck
     cy.get('[data-cy="deckDeleteCard"]:first').click();
@@ -143,6 +145,7 @@ describe('Deck builder page', () => {
       '1 ghūl'
     ].join('\n');
 
+    cy.get('[data-cy="goToImportMode"]').click();
     cy.get('[data-cy="importDeckTextarea"]').type(input);
     cy.get('[data-cy="importDeckButton"]').click();
 
@@ -163,11 +166,20 @@ describe('Deck builder page', () => {
       '2 Imp'
     ].join('\n');
 
+    // should be able to enter and exist import mode
+    cy.get('[data-cy="goToImportMode"]').click();
+    cy.get('[data-cy="importDeckTextarea"]').should('be.visible');
+    cy.get('[data-cy="deckBuilderActions"]').should('not.be.visible');
+    cy.get('[data-cy="cancelImportMode"]').click();
+    cy.get('[data-cy="importDeckTextarea"]').should('not.be.visible');
+
+    cy.get('[data-cy="goToImportMode"]').click();
     cy.get('[data-cy="importDeckTextarea"]').type(input);
     cy.get('[data-cy="importDeckButton"]').click();
     cy.get('[data-cy="exportDeckButton"]').click();
 
     cy.get('[data-cy="exportDeckSuccess"]').contains('Copied');
+    cy.get('[data-cy="deckBuilderActions"]').should('be.visible');
   });
 
   it('should clear filters', function() {

--- a/next/components/deck-builder-action-buttons.js
+++ b/next/components/deck-builder-action-buttons.js
@@ -1,0 +1,50 @@
+import PropTypes from 'prop-types';
+import DeckExport from '../components/deck-export';
+import SaveDeck from '../components/save-deck';
+
+export default function DeckBuilderActionButtons(props) {
+  const {
+    cardCount,
+    importMode,
+    deckId,
+    deckInProgress,
+    setDeckInProgress,
+    onClear
+  } = props;
+
+  if (!cardCount || importMode) return null;
+
+  return (
+    <div className="action-buttons" data-cy="deckBuilderActions">
+      <style jsx>{`
+        .action-buttons {
+          display: flex;
+          justify-content: space-between;
+        }
+        :global(.save-deck-container),
+        :global(.deck-export-container),
+        .clear-button-container {
+          width: 106px;
+        }
+      `}</style>
+      <SaveDeck
+        deckId={deckId}
+        deckInProgress={deckInProgress}
+        setDeckInProgress={setDeckInProgress}
+      />
+      <div className="clear-button-container">
+        <button onClick={onClear}>Clear</button>
+      </div>
+      <DeckExport deckInProgress={deckInProgress} />
+    </div>
+  );
+}
+
+DeckBuilderActionButtons.propTypes = {
+  deckId: PropTypes.number,
+  deckInProgress: PropTypes.object,
+  onClear: PropTypes.func,
+  setDeckInProgress: PropTypes.func,
+  importMode: PropTypes.bool,
+  cardCount: PropTypes.number
+};

--- a/next/components/deck-builder-sidebar.js
+++ b/next/components/deck-builder-sidebar.js
@@ -97,14 +97,11 @@ export default function DeckBuilderSidebar(props) {
       <button onClick={() => clearDeck(props.onClear)}>Clear Deck</button>
       <div className="deck-in-progress" data-cy="deckInProgress">
         <h2 className="build-deck-title">- OR - BUILD YOUR DECK</h2>
-        <EditDeckName
-          deckName={deckInProgress.deckName}
-          onChange={updateDeckName}
-        />
         <div className="card-count">
           Cards: <span>{cardCount}</span>
         </div>
         <DeckCardTable
+          updateDeckName={updateDeckName}
           deck={deckInProgress}
           deleteCard={deleteCardFromTable}
           switchToCards={switchToCards}

--- a/next/components/deck-builder-sidebar.js
+++ b/next/components/deck-builder-sidebar.js
@@ -1,15 +1,16 @@
-import React, { useState } from 'react';
+import React, { useState, useContext } from 'react';
 import PropTypes from 'prop-types';
 import ImportDeck from '../components/import-deck';
 import DeckExport from '../components/deck-export';
 import DeckCardTable from '../components/deck-card-table';
-import EditDeckName from '../components/edit-deck-name';
 import SaveDeck from '../components/save-deck';
 import {
   initializeDeckBuilder,
   resetDeckBuilderSavedState,
   getCardCount
 } from '../lib/deck-utils';
+import { ThemeContext } from './theme-context';
+import DeckBuilderActionButtons from './deck-builder-action-buttons';
 
 export default function DeckBuilderSidebar(props) {
   const {
@@ -19,7 +20,9 @@ export default function DeckBuilderSidebar(props) {
     switchToCards,
     setTab
   } = props;
+  const theme = useContext(ThemeContext);
   const [mainDeckInput, setMainDeckInput] = useState('');
+  const [importMode, setImportMode] = useState(false);
 
   const updateDeckName = e => {
     setDeckInProgress({
@@ -70,8 +73,24 @@ export default function DeckBuilderSidebar(props) {
           font-weight: bold;
         }
         .build-deck-title {
-          text-transform: uppercase;
           text-align: center;
+          margin-bottom: 15px;
+          font-size: 18px;
+        }
+        .action-button-border {
+          margin-top: 18px;
+          margin-bottom: 10px;
+          margin-left: auto;
+          margin-right: auto;
+          width: 90%;
+          border: 0;
+          height: 1px;
+          background-image: linear-gradient(
+            to right,
+            ${theme.orangeSeparatorSecondaryColor},
+            ${theme.orangeSeparatorColor},
+            ${theme.orangeSeparatorSecondaryColor}
+          );
         }
 
         @media only screen and (max-width: 600px) {
@@ -80,34 +99,43 @@ export default function DeckBuilderSidebar(props) {
           }
         }
       `}</style>
-      <h2 className="build-deck-title">Import Deck from Mythgard</h2>
       <ImportDeck
         mainDeckInput={mainDeckInput}
         handleInputChange={e => {
           setMainDeckInput(e.target.value);
         }}
         updateImportedDeck={updateImportedDeck}
+        importMode={importMode}
+        setImportMode={setImportMode}
       />
-      <DeckExport deckInProgress={deckInProgress} />
-      <SaveDeck
+      <hr className="action-button-border" />
+      <DeckBuilderActionButtons
+        cardCount={cardCount}
+        importMode={importMode}
         deckId={deckId}
         deckInProgress={deckInProgress}
         setDeckInProgress={setDeckInProgress}
+        onClear={() => clearDeck(props.onClear)}
       />
-      <button onClick={() => clearDeck(props.onClear)}>Clear Deck</button>
-      <div className="deck-in-progress" data-cy="deckInProgress">
-        <h2 className="build-deck-title">- OR - BUILD YOUR DECK</h2>
-        <div className="card-count">
-          Cards: <span>{cardCount}</span>
+      {!importMode && !cardCount && (
+        <div className="build-deck-title">
+          - OR - Select a card to begin building
         </div>
-        <DeckCardTable
-          updateDeckName={updateDeckName}
-          deck={deckInProgress}
-          deleteCard={deleteCardFromTable}
-          switchToCards={switchToCards}
-          setTab={setTab}
-        />
-      </div>
+      )}
+      {!importMode && (
+        <div className="deck-in-progress" data-cy="deckInProgress">
+          <div className="card-count">
+            Cards: <span>{cardCount}</span>
+          </div>
+          <DeckCardTable
+            updateDeckName={updateDeckName}
+            deck={deckInProgress}
+            deleteCard={deleteCardFromTable}
+            switchToCards={switchToCards}
+            setTab={setTab}
+          />
+        </div>
+      )}
     </div>
   );
 }

--- a/next/components/deck-builder-user.js
+++ b/next/components/deck-builder-user.js
@@ -1,0 +1,61 @@
+import { useContext } from 'react';
+import Link from 'next/link';
+import { ThemeContext } from './theme-context';
+import UserContext from '../components/user-context';
+
+export default function DeckBuilderUser() {
+  const theme = useContext(ThemeContext);
+  const { user } = useContext(UserContext);
+
+  const userElement = (
+    <Link href={user ? '/account' : '/auth/google'}>
+      <a data-cy="userLink" className="link">
+        {user?.username || 'Guest'}
+      </a>
+    </Link>
+  );
+
+  return (
+    <div className="deck-author">
+      <style jsx>{`
+        .deck-author {
+          display: flex;
+          justify-content: space-between;
+          margin: 10px 0;
+        }
+        .login-link,
+        .user-link {
+          text-decoration: none;
+          color: ${theme.fontColorAccent};
+        }
+        .login-link:before {
+          text-decoration: none;
+          content: '\u25b6';
+          margin-right: 3px;
+          font-size: 10px;
+        }
+        .login-link {
+          font-size: 14px;
+        }
+        .user-link {
+          font-size: inherit;
+        }
+      `}</style>
+      <div>
+        by{' '}
+        <Link href={user ? '/account' : '/auth/google'}>
+          <a data-cy="userLink" className="user-link">
+            {user?.username || 'Guest'}
+          </a>
+        </Link>
+      </div>
+      {!user && (
+        <Link href="/auth/google">
+          <a data-cy="loginToSave" className="login-link">
+            Login/Register
+          </a>
+        </Link>
+      )}
+    </div>
+  );
+}

--- a/next/components/deck-builder-user.js
+++ b/next/components/deck-builder-user.js
@@ -28,12 +28,6 @@ export default function DeckBuilderUser() {
           text-decoration: none;
           color: ${theme.fontColorAccent};
         }
-        .login-link:before {
-          text-decoration: none;
-          content: '\u25b6';
-          margin-right: 3px;
-          font-size: 10px;
-        }
         .login-link {
           font-size: 14px;
         }
@@ -48,7 +42,10 @@ export default function DeckBuilderUser() {
       </div>
       {!user && (
         <Link href="/auth/google">
-          <a data-cy="loginToSave" className="login-link">
+          <a
+            data-cy="loginToSave"
+            className="login-link call-to-action-chevron"
+          >
             Login/Register
           </a>
         </Link>

--- a/next/components/deck-builder-user.js
+++ b/next/components/deck-builder-user.js
@@ -37,9 +37,6 @@ export default function DeckBuilderUser() {
         .login-link {
           font-size: 14px;
         }
-        .user-link {
-          font-size: inherit;
-        }
       `}</style>
       <div>
         by{' '}

--- a/next/components/deck-card-table-edit-meta.js
+++ b/next/components/deck-card-table-edit-meta.js
@@ -17,12 +17,6 @@ export default function DeckCardsTableEditMeta(props) {
           font-style: normal;
           font-weight: normal;
         }
-        .edit-button:before {
-          text-decoration: none;
-          content: '\u25b6';
-          margin-right: 3px;
-          font-size: 10px;
-        }
         .no-meta-value {
           text-transform: uppercase;
         }
@@ -31,7 +25,7 @@ export default function DeckCardsTableEditMeta(props) {
       <div>
         <button
           data-cy="editMetaValue"
-          className="edit-button"
+          className="edit-button call-to-action-chevron"
           onClick={onEditClick}
         >
           edit

--- a/next/components/deck-card-table.js
+++ b/next/components/deck-card-table.js
@@ -4,13 +4,16 @@ import { ThemeContext } from './theme-context';
 import { FACTION_COLORS } from '../constants/factions';
 import DeckCardsTableRow from './deck-card-table-row';
 import DeckCardsTableEditMeta from './deck-card-table-edit-meta';
+import EditDeckName from './edit-deck-name';
+import DeckBuilderUser from './deck-builder-user';
 
 export default function DeckCardsTable({
   deck,
   deleteCard,
   onlyTable,
   switchToCards,
-  setTab
+  setTab,
+  updateDeckName
 }) {
   const deckCards = deck && Object.values(deck.mainDeck);
   const colspan = deleteCard ? 3 : 2;
@@ -88,18 +91,18 @@ export default function DeckCardsTable({
           border-collapse: collapse;
           width: 100%;
         }
+        .deck-author {
+          margin: 10px 0;
+        }
         td {
           padding: 6px;
           border: ${theme.cardTableBorder};
         }
-        .deck-title {
-          font-size: 30px;
-          margin: 0 0 20px 5px;
-        }
       `}</style>
       {!onlyTable && (
-        <div className="deck-title">{deck.deckName || '[untitled]'}</div>
+        <EditDeckName deckName={deck.deckName} onChange={updateDeckName} />
       )}
+      {!onlyTable && <DeckBuilderUser />}
       <table className="deck-card-table" data-cy="deckCardTable">
         <tbody>
           <tr>
@@ -167,6 +170,7 @@ DeckCardsTable.propTypes = {
     }),
     errors: PropTypes.arrayOf(PropTypes.string),
     switchToCards: PropTypes.func,
-    setTab: PropTypes.func
+    setTab: PropTypes.func,
+    updateDeckName: PropTypes.func
   })
 };

--- a/next/components/edit-deck-name.js
+++ b/next/components/edit-deck-name.js
@@ -10,6 +10,7 @@ export default function EditDeckName(props) {
     <div className="deck-name-container">
       <style jsx>{`
         input {
+          width: 100%;
           background-color: transparent;
           border: ${theme.inputBorder};
           border-radius: 10px;

--- a/next/components/edit-deck-name.js
+++ b/next/components/edit-deck-name.js
@@ -1,19 +1,35 @@
-import React from 'react';
+import { useContext } from 'react';
 import PropTypes from 'prop-types';
-import SearchFormText from './search-form-text.js';
+import { ThemeContext } from './theme-context';
 
 export default function EditDeckName(props) {
   const { deckName, onChange } = props;
+  const theme = useContext(ThemeContext);
 
   return (
-    <SearchFormText
-      label="Deck Name"
-      value={deckName}
-      name="text"
-      cyName="deckTitle"
-      onChange={onChange}
-      placeholder="Enter a name..."
-    />
+    <div className="deck-name-container">
+      <style jsx>{`
+        input {
+          background-color: transparent;
+          border: ${theme.inputBorder};
+          border-radius: 10px;
+          font-size: 20px;
+          font-family: ${theme.fontFamily};
+          padding: 5px 5px 7px 5px;
+          color: ${theme.fontColor};
+        }
+        input::placeholder {
+          padding: 5px 5px 7px 5px;
+          color: ${theme.fontColor};
+        }
+      `}</style>
+      <input
+        value={deckName}
+        data-cy="deckTitle"
+        onChange={onChange}
+        placeholder="Untitled"
+      />
+    </div>
   );
 }
 

--- a/next/components/import-deck.js
+++ b/next/components/import-deck.js
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import PropTypes from 'prop-types';
 import { useQuery } from 'react-apollo-hooks';
 
@@ -28,7 +29,9 @@ const handleImport = (
 export default function ImportDeck({
   mainDeckInput,
   handleInputChange,
-  updateImportedDeck
+  updateImportedDeck,
+  importMode,
+  setImportMode
 }) {
   const {
     loading: cardsLoading,
@@ -43,6 +46,21 @@ export default function ImportDeck({
     error: powerError,
     data: powerData
   } = useQuery(allPowersQuery);
+
+  if (!importMode) {
+    return (
+      <div>
+        <style jsx>{`
+          div {
+            margin-top: 20px;
+          }
+        `}</style>
+        <button onClick={e => setImportMode(true)} data-cy="goToImportMode">
+          Import
+        </button>
+      </div>
+    );
+  }
 
   const error = cardsError || pathError || powerError;
   if (error) return <ErrorMessage message={error.message} />;
@@ -64,35 +82,44 @@ export default function ImportDeck({
 
     if (confirmation) {
       handleImport(mainDeckInput, updateImportedDeck, cards, paths, powers);
+      setImportMode(false);
     }
   };
 
   return (
     <div className="import-deck-container">
       <style jsx>{`
-        .import-deck-container {
+        .import-button {
+          margin-top: 20px;
           margin-bottom: 10px;
         }
         .import-deck-textarea {
-          margin-top: 10px;
+          margin-top: 30px;
           margin-bottom: 10px;
           max-width: 100%;
           width: 100%;
         }
       `}</style>
+      <button
+        onClick={onClick}
+        data-cy="importDeckButton"
+        className="import-button"
+      >
+        Import Decklist
+      </button>
+      <button onClick={_ => setImportMode(false)} data-cy="cancelImportMode">
+        Cancel
+      </button>
       <textarea
         className="import-deck-textarea"
         data-cy="importDeckTextarea"
         cols="39"
-        rows="2"
+        rows="20"
         value={mainDeckInput}
         name="mainDeckInput"
         onChange={handleInputChange}
         placeholder="Paste deck from Mythgard..."
       />
-      <button onClick={onClick} data-cy="importDeckButton">
-        Import
-      </button>
     </div>
   );
 }
@@ -113,5 +140,7 @@ ImportDeck.propTypes = {
     })
   }),
   handleInputChange: PropTypes.func,
-  updateImportedDeck: PropTypes.func
+  updateImportedDeck: PropTypes.func,
+  importMode: PropTypes.bool,
+  setImportMode: PropTypes.func
 };

--- a/next/components/layout.js
+++ b/next/components/layout.js
@@ -352,6 +352,13 @@ function Layout({ title, desc, image, router, children }) {
             margin-bottom: 25px;
           }
 
+          .call-to-action-chevron:before {
+            text-decoration: none;
+            content: '\u25b6';
+            margin-right: 3px;
+            font-size: 10px;
+          }
+
           .external-link::after {
             background-image: url('https://cdn.mythgardhub.com/icons/newWindow.svg');
             background-size: 12px 12px;

--- a/next/components/save-deck.js
+++ b/next/components/save-deck.js
@@ -42,7 +42,7 @@ export default function SaveDeck({
     saveButton = (
       <Link href="/auth/google">
         <a className="button" data-cy="saveDeck">
-          Login to Save
+          Save
         </a>
       </Link>
     );

--- a/next/components/theme-context.js
+++ b/next/components/theme-context.js
@@ -42,6 +42,8 @@ export const themes = {
     footerLinkColor: mgColors.orange,
     footerTextColor: mgColors.mediumLighterGray,
     selectedPageColor: mgColors.blue,
+    orangeSeparatorColor: mgColors.orange,
+    orangeSeparatorSecondaryColor: mgColors.blackPearl,
     blueFactionColor: mgColors.blue,
     redFactionColor: mgColors.red,
     yellowFactionColor: mgColors.yellow,

--- a/next/components/welcome-banner.js
+++ b/next/components/welcome-banner.js
@@ -25,11 +25,6 @@ export default function WelcomeBanner() {
           align-items: center;
         }
 
-        .welcome-banner-link:before {
-          content: '\u25b6';
-          margin-right: 3px;
-        }
-
         .welcome-banner-link-username:before {
           content: none;
         }
@@ -71,7 +66,7 @@ export default function WelcomeBanner() {
       `}</style>
 
       <a
-        className="welcome-banner-link"
+        className="welcome-banner-link call-to-action-chevron"
         href={`mailto:${process.env.EMAIL_MG_CONTACT}`}
       >
         Contact
@@ -84,7 +79,10 @@ export default function WelcomeBanner() {
       <span className="spacer"></span>
 
       {!user && (
-        <a href="/auth/google" className="welcome-banner-link">
+        <a
+          href="/auth/google"
+          className="welcome-banner-link call-to-action-chevron"
+        >
           Login/Register
         </a>
       )}

--- a/next/lib/deck-utils.js
+++ b/next/lib/deck-utils.js
@@ -6,7 +6,7 @@ import { RARITY_MAX_CARDS } from '../constants/rarities';
 
 export const initializeDeckBuilder = () => {
   return {
-    deckName: '',
+    deckName: 'Untitled',
     deckPath: {},
     deckPower: {},
     deckCoverArt: '',

--- a/next/lib/export-utils.test.js
+++ b/next/lib/export-utils.test.js
@@ -13,7 +13,7 @@ describe('Export utility methods', () => {
 
       const result = exportDeck(deckInProgress);
       const expected = [
-        'name: ',
+        'name: Untitled',
         'path: ',
         'power: ',
         'coverart: ',

--- a/next/lib/import-utils.test.js
+++ b/next/lib/import-utils.test.js
@@ -558,7 +558,7 @@ describe('Import utility methods', () => {
 
       expect(result.errors.length).toEqual(1);
       expect(result.deckCoverArt).toEqual('');
-      expect(result.deckName).toEqual('');
+      expect(result.deckName).toEqual('Untitled');
       expect(result.deckPath).toEqual({});
       expect(result.deckPower).toEqual({});
       expect(Object.values(result.mainDeck).length).toEqual(0);


### PR DESCRIPTION
PR 2 for deck builder refactor. This time:

- The dedicated place for editing the deck name was removed. Now merged with the name display.
- Added a "by []" that either shows guest and invites the user to log in or shows their user name

Again, no new tests because this ain't over yet. However, this branch and the parent branch could be deployed at any time since they're just a refactor of the existing state. Once we start messing more with the page, it won't be the case