### PR TITLE
Top level links to sub pages

### DIFF
--- a/next/components/page-banner.js
+++ b/next/components/page-banner.js
@@ -2,35 +2,67 @@ import { useContext } from 'react';
 import { ThemeContext } from './theme-context';
 import PropTypes from 'prop-types';
 
-function PageBanner({ children, image }) {
+function PageBanner({ children, image, url }) {
+  return (
+    (typeof(url) !== 'undefined' || url !== null )
+    ? _bannerWithUrl(children, image, url)
+    : _bannerWithoutUrl(children, image)
+  );
+}
+
+function _bannerWithoutUrl(children, image){
   const theme = useContext(ThemeContext);
+
   return (
     <div className="page-banner">
-      <style jsx>{`
-        .page-banner {
-          border-top: ${theme.border};
-          border-bottom: ${theme.border};
-          background: url(${image}) left no-repeat, ${theme.background};
-          height: 70px;
-          display: flex;
-          flex-direction: row-reverse;
-          align-items: center;
-        }
-        .page-banner h1 {
-          margin: 0;
-          padding-right: 0.5em;
-          text-align: right; /* multiline situations */
-        }
-
-        @media only screen and (max-width: 600px) {
-          .page-banner {
-            background: unset;
-          }
-        }
-      `}</style>
+      { _bannerStyling(image) }
       <h1 data-cy="header">{children}</h1>
     </div>
   );
+}
+
+function _bannerWithUrl(children, image, url){
+  return (
+    <a href={url} className='page-banner-link'>
+      <style jsx>{`
+        .page-banner-link { text-decoration: none; } 
+      `}</style>
+
+      <div className="page-banner">
+        { _bannerStyling(image) }
+        <h1 data-cy="header">{children}</h1>
+      </div>
+    </a>
+  );
+}
+
+function _bannerStyling(backgroundImage){
+  const theme = useContext(ThemeContext);
+
+  return (
+    <style jsx>{`
+      .page-banner {
+        border-top: ${theme.border};
+        border-bottom: ${theme.border};
+        background: url(${backgroundImage}) left no-repeat, ${theme.background};
+        height: 70px;
+        display: flex;
+        flex-direction: row-reverse;
+        align-items: center;
+      }
+      .page-banner h1 {
+        margin: 0;
+        padding-right: 0.5em;
+        text-align: right; /* multiline situations */
+      }
+
+      @media only screen and (max-width: 600px) {
+        .page-banner {
+          background: unset;
+        }
+      }
+    `}</style>
+  )
 }
 
 PageBanner.IMG_ARTICLES = `${process.env.MG_CDN}/banner/Banner_Articles.jpg`;
@@ -43,6 +75,7 @@ PageBanner.IMG_HOME_TOP = `${process.env.MG_CDN}/banner/Banner_Home_Top.jpg`;
 
 PageBanner.propTypes = {
   children: PropTypes.any,
+  url: PropTypes.string,
   image: PropTypes.oneOf([
     PageBanner.IMG_ARTICLES,
     PageBanner.IMG_CARDS,

--- a/next/components/page-banner.js
+++ b/next/components/page-banner.js
@@ -5,67 +5,82 @@ import Link from 'next/link';
 
 function PageBanner({ children, image, url }) {
   return (
-    (typeof(url) !== 'undefined' || url !== null )
+    (typeof(url) !== 'undefined')
     ? _bannerWithUrl(children, image, url)
     : _bannerWithoutUrl(children, image)
   );
 }
 
-function _bannerWithoutUrl(children, image){
+function _bannerWithoutUrl(children, backgroundImage){
   const theme = useContext(ThemeContext);
 
   return (
     <div className="page-banner">
-      { _bannerStyling(image) }
+      <style jsx>{`
+        .page-banner {
+          border-top: ${theme.border};
+          border-bottom: ${theme.border};
+          background: url(${backgroundImage}) left no-repeat, ${theme.background};
+          height: 70px;
+          display: flex;
+          flex-direction: row-reverse;
+          align-items: center;
+        }
+        .page-banner h1 {
+          margin: 0;
+          padding-right: 0.5em;
+          text-align: right; /* multiline situations */
+        }
+
+        @media only screen and (max-width: 600px) {
+          .page-banner {
+            background: unset;
+          }
+        }
+      `}</style>
       <h1 data-cy="header">{children}</h1>
     </div>
   );
 }
 
-function _bannerWithUrl(children, image, url){
+function _bannerWithUrl(children, backgroundImage, url){
+  const theme = useContext(ThemeContext);
+
   return (
     <Link href={url}>
       <a className='page-banner-link'>
         <style jsx>{`
           .page-banner-link { text-decoration: none; }
+
+          .page-banner {
+            border-top: ${theme.border};
+            border-bottom: ${theme.border};
+            background: url(${backgroundImage}) left no-repeat, ${theme.background};
+            height: 70px;
+            display: flex;
+            flex-direction: row-reverse;
+            align-items: center;
+          }
+
+          .page-banner h1 {
+            margin: 0;
+            padding-right: 0.5em;
+            text-align: right; /* multiline situations */
+          }
+
+          @media only screen and (max-width: 600px) {
+            .page-banner {
+              background: unset;
+            }
+          }
         `}</style>
 
         <div className="page-banner">
-          { _bannerStyling(image) }
           <h1 data-cy="header">{children}</h1>
         </div>
       </a>
     </Link>
   );
-}
-
-function _bannerStyling(backgroundImage){
-  const theme = useContext(ThemeContext);
-
-  return (
-    <style jsx>{`
-      .page-banner {
-        border-top: ${theme.border};
-        border-bottom: ${theme.border};
-        background: url(${backgroundImage}) left no-repeat, ${theme.background};
-        height: 70px;
-        display: flex;
-        flex-direction: row-reverse;
-        align-items: center;
-      }
-      .page-banner h1 {
-        margin: 0;
-        padding-right: 0.5em;
-        text-align: right; /* multiline situations */
-      }
-
-      @media only screen and (max-width: 600px) {
-        .page-banner {
-          background: unset;
-        }
-      }
-    `}</style>
-  )
 }
 
 PageBanner.IMG_ARTICLES = `${process.env.MG_CDN}/banner/Banner_Articles.jpg`;

--- a/next/components/page-banner.js
+++ b/next/components/page-banner.js
@@ -6,12 +6,12 @@ import Link from 'next/link';
 function PageBanner({ children, image, url }) {
   return (
     (typeof(url) !== 'undefined')
-    ? _bannerWithUrl(children, image, url)
-    : _bannerWithoutUrl(children, image)
+    ? _bannerWithLink(children, image, url)
+    : _bannerWithoutLink(children, image)
   );
 }
 
-function _bannerWithoutUrl(children, backgroundImage){
+function _bannerWithoutLink(children, backgroundImage){
   const theme = useContext(ThemeContext);
 
   return (
@@ -43,7 +43,7 @@ function _bannerWithoutUrl(children, backgroundImage){
   );
 }
 
-function _bannerWithUrl(children, backgroundImage, url){
+function _bannerWithLink(children, backgroundImage, url){
   const theme = useContext(ThemeContext);
 
   return (

--- a/next/pages/card.js
+++ b/next/pages/card.js
@@ -50,7 +50,7 @@ export default withRouter(({ router }) => {
       desc={description}
       image={getImagePath(data.card.name, data.card.set)}
     >
-      <PageBanner image={PageBanner.IMG_CARDS}>Cards</PageBanner>
+      <PageBanner image={PageBanner.IMG_CARDS} url="/cards">Cards</PageBanner>
       <Card card={data.card} />
     </Layout>
   );

--- a/next/pages/deck.js
+++ b/next/pages/deck.js
@@ -46,7 +46,7 @@ export default withRouter(({ router }) => {
 
   return (
     <Layout title={title} desc={description}>
-      <PageBanner image={PageBanner.IMG_DECKS}>Decks</PageBanner>
+      <PageBanner image={PageBanner.IMG_DECKS} url="/decks">Decks</PageBanner>
       <Deck deck={data.deck} />
     </Layout>
   );

--- a/next/pages/event.js
+++ b/next/pages/event.js
@@ -129,16 +129,9 @@ export default withRouter(({ router }) => {
             margin: 10px 0 0;
             float: right;
           }
-          .bannerLink {
-            text-decoration: none;
-          }
         `}
       </style>
-      <Link href="/events">
-        <a className="bannerLink">
-          <PageBanner image={PageBanner.IMG_EVENTS}>Events</PageBanner>
-        </a>
-      </Link>
+      <PageBanner image={PageBanner.IMG_EVENTS} url="/events">Events</PageBanner>
       <a
         className="external-link accent bold tourneyLink"
         data-cy="tourneyLink"


### PR DESCRIPTION
Implements issue #204 

This PR allows setting `PageBanner` components as links, by wrapping the banner in an `a` tag. This can be done by passing a `url="<path>"` prop to the PageBanner component, which will then link to the given path.

This PR also adds the link to all sub-pages (eg. `/card`, `/event`) but not the top-level pages (eg. `/cards`, `/events`). This was done to be as true as possible to the ticket specifications, but assigning similar functionality to the top-level pages would be a quick effort. Let me know if I should add those.

This feature is implemented by checking for the `url` prop and invoking the correct render sub-function. This seemed the easiest way to implement, but if there's a better and more conventional method, let me know and I will update. I've worked with React before, but the React projects I've inherited didn't provide the best examples to approach such a situation. Creating two distinct PageBanner components seemed like overkill.

Originally I did try to extracting the shared styling to a helper function, but styled-jsx didn't know how to interpret that, unfortunately, so the styling is repeated.

(P.S. If there's a better branch to merge into other than Master, I'll re-open with that branch as the target)