### PR TITLE
Deck mana curve using our old friend highcharts

### DIFF
--- a/e2e/cypress/integration/deck-builder-page.js
+++ b/e2e/cypress/integration/deck-builder-page.js
@@ -28,6 +28,7 @@ describe('Deck builder page', () => {
     cy.get('[data-cy="goToImportMode"]').should('be.visible');
     cy.get('[data-cy="importDeckButton"]').should('not.be.visible');
     cy.get('[data-cy="deckBuilderActions"]').should('not.be.visible');
+    cy.get('[data-cy="deckManaCurve"]').should('not.be.visible');
     cy.get(cardList).should('be.visible');
     cy.get(deckInProgress).should('be.visible');
     cy.get('[data-cy="factionFilters"]').should('be.visible');
@@ -41,6 +42,7 @@ describe('Deck builder page', () => {
     cy.get(deckInProgress).should('be.visible');
     cy.get(deckCardRow).should('have.length', 2);
     cy.get('[data-cy="deckBuilderActions"]').should('be.visible');
+    cy.get('[data-cy="deckManaCurve"]').should('be.visible');
 
     // basic test - delete a card from the deck
     cy.get('[data-cy="deckDeleteCard"]:first').click();

--- a/e2e/cypress/integration/deck-page.js
+++ b/e2e/cypress/integration/deck-page.js
@@ -8,6 +8,7 @@ describe('Deck Page', function() {
     cy.get('[data-cy="deckPageType"]').should('be.visible');
     cy.get('[data-cy="deckPageArchetype"]').should('be.visible');
     cy.get('[data-cy="deckPageCardCount"]').should('be.visible');
+    cy.get('[data-cy="deckManaCurve"]').should('be.visible');
     cy.get('[data-cy="deckPageType"]').should('contain', 'Standard');
     cy.get('[data-cy="deckPageArchetype"]').should('contain', 'Unknown');
     cy.get('[data-cy="deckPageCardCount"]').should('contain', '2');

--- a/next/components/deck-builder-sidebar.js
+++ b/next/components/deck-builder-sidebar.js
@@ -135,6 +135,7 @@ export default function DeckBuilderSidebar(props) {
       )}
       {pageMode !== PAGE_MODES.IMPORT && (
         <div className="deck-in-progress" data-cy="deckInProgress">
+          {cardCount > 0 && <DeckManaCurve cards={deckInProgress.mainDeck} />}
           <div className="card-count">
             Cards: <span>{cardCount}</span>
           </div>
@@ -145,7 +146,6 @@ export default function DeckBuilderSidebar(props) {
             switchToCards={switchToCards}
             setTab={setTab}
           />
-          <DeckManaCurve cards={deckInProgress.mainDeck} />
         </div>
       )}
     </div>

--- a/next/components/deck-builder-sidebar.js
+++ b/next/components/deck-builder-sidebar.js
@@ -11,6 +11,7 @@ import { ThemeContext } from './theme-context';
 import DeckBuilderActionButtons from './deck-builder-action-buttons';
 import { PAGE_MODES } from '../constants/deck-builder';
 import DeckBuilderPublishMode from './deck-builder-publish-mode';
+import DeckManaCurve from './deck-mana-curve';
 
 export default function DeckBuilderSidebar(props) {
   const {
@@ -144,6 +145,7 @@ export default function DeckBuilderSidebar(props) {
             switchToCards={switchToCards}
             setTab={setTab}
           />
+          <DeckManaCurve cards={deckInProgress.mainDeck} />
         </div>
       )}
     </div>

--- a/next/components/deck-mana-curve.js
+++ b/next/components/deck-mana-curve.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import Highcharts from 'highcharts';
 import HighchartsExporting from 'highcharts/modules/exporting';
 import HighchartsReact from 'highcharts-react-official';
-import { getManaCurve } from '../lib/deck-stats';
+import { getManaCurveHighchartsSeries } from '../lib/deck-stats';
 import { ThemeContext } from './theme-context';
 
 if (typeof Highcharts === 'object') {
@@ -60,7 +60,7 @@ export default function DeckManaCurve({ cards }) {
         stacking: 'normal'
       }
     },
-    series: getManaCurve(cards, theme)
+    series: getManaCurveHighchartsSeries(cards, theme)
   };
 
   return (

--- a/next/components/deck-mana-curve.js
+++ b/next/components/deck-mana-curve.js
@@ -1,15 +1,17 @@
+import { useContext } from 'react';
 import PropTypes from 'prop-types';
 import Highcharts from 'highcharts';
 import HighchartsExporting from 'highcharts/modules/exporting';
 import HighchartsReact from 'highcharts-react-official';
 import { getManaCurve } from '../lib/deck-stats';
+import { ThemeContext } from './theme-context';
 
 if (typeof Highcharts === 'object') {
   HighchartsExporting(Highcharts);
 }
 
 export default function DeckManaCurve({ cards }) {
-  const manaCurve = getManaCurve(cards);
+  const theme = useContext(ThemeContext);
   const options = {
     chart: {
       type: 'column',
@@ -27,12 +29,15 @@ export default function DeckManaCurve({ cards }) {
     },
     xAxis: {
       categories: ['1', '2', '3', '4', '5', '6+'],
-      crosshair: true
+      crosshair: true,
+      lineColor: '#666666'
     },
     yAxis: {
       title: {
         enabled: false
       },
+      tickInterval: 10,
+      gridLineColor: '#666666',
       min: 0
     },
     tooltip: {
@@ -40,7 +45,7 @@ export default function DeckManaCurve({ cards }) {
         '<span style="font-size:10px">Mana cost: {point.key}</span><table>',
       pointFormat:
         '<tr>' +
-        '<td style="padding:0; font-size:10px;">{series.name}:</td>' +
+        '<td style="padding:0; font-size:10px;text-transform:capitalize;">{series.name}:</td>' +
         '<td style="padding:0;font-size:10px;"><b>{point.y}</b></td>' +
         '</tr>',
       footerFormat: '</table>',
@@ -49,17 +54,13 @@ export default function DeckManaCurve({ cards }) {
     },
     plotOptions: {
       column: {
-        pointPadding: 0.2,
-        borderWidth: 0
+        pointPadding: 0,
+        borderWidth: 0.3,
+        borderColor: theme.background,
+        stacking: 'normal'
       }
     },
-    series: [
-      {
-        name: 'Cards',
-        showInLegend: false,
-        data: manaCurve
-      }
-    ]
+    series: getManaCurve(cards, theme)
   };
 
   return (

--- a/next/components/deck-mana-curve.js
+++ b/next/components/deck-mana-curve.js
@@ -55,7 +55,7 @@ export default function DeckManaCurve({ cards }) {
     plotOptions: {
       column: {
         pointPadding: 0,
-        borderWidth: 0.3,
+        borderWidth: 0.1,
         borderColor: theme.background,
         stacking: 'normal'
       }

--- a/next/components/deck-mana-curve.js
+++ b/next/components/deck-mana-curve.js
@@ -1,0 +1,75 @@
+import PropTypes from 'prop-types';
+import Highcharts from 'highcharts';
+import HighchartsExporting from 'highcharts/modules/exporting';
+import HighchartsReact from 'highcharts-react-official';
+import { getManaCurve } from '../lib/deck-stats';
+
+if (typeof Highcharts === 'object') {
+  HighchartsExporting(Highcharts);
+}
+
+export default function DeckManaCurve({ cards }) {
+  const manaCurve = getManaCurve(cards);
+  const options = {
+    chart: {
+      type: 'column',
+      backgroundColor: 'rgba(0,0,0,0)',
+      height: '200px'
+    },
+    exporting: {
+      enabled: false
+    },
+    credits: {
+      enabled: false
+    },
+    title: {
+      text: ''
+    },
+    xAxis: {
+      categories: ['1', '2', '3', '4', '5', '6+'],
+      crosshair: true
+    },
+    yAxis: {
+      title: {
+        enabled: false
+      },
+      min: 0
+    },
+    tooltip: {
+      headerFormat:
+        '<span style="font-size:10px">Mana cost: {point.key}</span><table>',
+      pointFormat:
+        '<tr>' +
+        '<td style="padding:0; font-size:10px;">{series.name}:</td>' +
+        '<td style="padding:0;font-size:10px;"><b>{point.y}</b></td>' +
+        '</tr>',
+      footerFormat: '</table>',
+      shared: true,
+      useHTML: true
+    },
+    plotOptions: {
+      column: {
+        pointPadding: 0.2,
+        borderWidth: 0
+      }
+    },
+    series: [
+      {
+        name: 'Cards',
+        showInLegend: false,
+        data: manaCurve
+      }
+    ]
+  };
+
+  return (
+    <div className="deck-mana-curve">
+      <style jsx>{``}</style>
+      <HighchartsReact highcharts={Highcharts} options={options} />
+    </div>
+  );
+}
+
+DeckManaCurve.propTypes = {
+  cards: PropTypes.array
+};

--- a/next/components/deck-mana-curve.js
+++ b/next/components/deck-mana-curve.js
@@ -42,7 +42,9 @@ export default function DeckManaCurve({ cards }) {
     },
     tooltip: {
       headerFormat:
-        '<span style="font-size:10px">Mana cost: {point.key}</span><table>',
+        '<span style="font-size:10px">' +
+        'Mana cost: {point.key}' +
+        '</span><table>',
       pointFormat:
         '<tr>' +
         '<td style="padding:0; font-size:10px;text-transform:capitalize;">{series.name}:</td>' +
@@ -64,7 +66,7 @@ export default function DeckManaCurve({ cards }) {
   };
 
   return (
-    <div className="deck-mana-curve">
+    <div className="deck-mana-curve" data-cy="deckManaCurve">
       <style jsx>{``}</style>
       <HighchartsReact highcharts={Highcharts} options={options} />
     </div>

--- a/next/components/deck.js
+++ b/next/components/deck.js
@@ -23,6 +23,7 @@ import EssenceIndicator from './essence-indicator.js';
 import FactionsIndicator from './factions-indicator.js';
 import { useContext } from 'react';
 import { ThemeContext } from '../components/theme-context.js';
+import DeckManaCurve from './deck-mana-curve';
 
 const getDeckToExport = (deckCards, deckName, path = null, power = null) => {
   const deckToExport = initializeDeckBuilder();
@@ -175,6 +176,11 @@ export default function Deck({ deck }) {
           </div>
           <div className="deck-stats-container">
             <div className="deck-stats">
+              <div className="stats-title">Mana Curve</div>
+              <hr className="gradient-hr" />
+              <div className="deck-stat">
+                <DeckManaCurve cards={cards} />
+              </div>
               <div className="stats-title">Essence</div>
               <hr className="gradient-hr" />
               <div className="deck-stat">

--- a/next/components/deck.js
+++ b/next/components/deck.js
@@ -176,11 +176,6 @@ export default function Deck({ deck }) {
           </div>
           <div className="deck-stats-container">
             <div className="deck-stats">
-              <div className="stats-title">Mana Curve</div>
-              <hr className="gradient-hr" />
-              <div className="deck-stat">
-                <DeckManaCurve cards={cards} />
-              </div>
               <div className="stats-title">Essence</div>
               <hr className="gradient-hr" />
               <div className="deck-stat">
@@ -205,6 +200,11 @@ export default function Deck({ deck }) {
               <hr className="gradient-hr" />
               <div className="deck-stat">
                 <FactionsIndicator factions={factions} />
+              </div>
+              <div className="stats-title">Mana Curve</div>
+              <hr className="gradient-hr" />
+              <div className="deck-stat">
+                <DeckManaCurve cards={cards} />
               </div>
             </div>
           </div>

--- a/next/lib/deck-stats.js
+++ b/next/lib/deck-stats.js
@@ -1,0 +1,21 @@
+export const getManaCurve = cards => {
+  const manaCosts = {
+    '1': 0,
+    '2': 0,
+    '3': 0,
+    '4': 0,
+    '5': 0,
+    '6+': 0
+  };
+
+  try {
+    Object.values(cards).forEach(card => {
+      const manaCost = card.card.mana >= 6 ? '6+' : card.card.mana.toString();
+      manaCosts[manaCost] += card.quantity;
+    });
+  } catch (e) {
+    console.error(e);
+  }
+
+  return Object.values(manaCosts);
+};

--- a/next/lib/deck-stats.js
+++ b/next/lib/deck-stats.js
@@ -1,33 +1,21 @@
 import { FACTION_NAMES, FACTION_COLORS } from '../constants/factions';
 import { mainFaction } from './card';
 
-const factionMainColor = (faction, theme) => {
-  let color = null;
-  switch (faction) {
-    case FACTION_COLORS.blue:
-      color = theme.blueFactionColor;
-      break;
-    case FACTION_COLORS.yellow:
-      color = theme.yellowFactionColor;
-      break;
-    case FACTION_COLORS.red:
-      color = theme.redFactionColor;
-      break;
-    case FACTION_COLORS.purple:
-      color = theme.purpleFactionColor;
-      break;
-    case FACTION_COLORS.orange:
-      color = theme.orangeFactionColor;
-      break;
-    case FACTION_COLORS.green:
-      color = theme.greenFactionColor;
-      break;
-  }
+const FACTION_COLORS_MAP = {};
 
-  return color;
+const factionMainColor = (faction, theme) => {
+  if (!FACTION_COLORS_MAP[FACTION_COLORS.blue]) {
+    FACTION_COLORS_MAP[FACTION_COLORS.blue] = theme.blueFactionColor;
+    FACTION_COLORS_MAP[FACTION_COLORS.yellow] = theme.yellowFactionColor;
+    FACTION_COLORS_MAP[FACTION_COLORS.purple] = theme.purpleFactionColor;
+    FACTION_COLORS_MAP[FACTION_COLORS.red] = theme.redFactionColor;
+    FACTION_COLORS_MAP[FACTION_COLORS.green] = theme.greenFactionColor;
+    FACTION_COLORS_MAP[FACTION_COLORS.orange] = theme.orangeFactionColor;
+  }
+  return FACTION_COLORS_MAP[faction];
 };
 
-const initializeManaCostsByFunction = theme => {
+const initializeManaCostsByFaction = theme => {
   return FACTION_NAMES.reduce((acc, f) => {
     acc[f] = {
       name: f,
@@ -48,7 +36,7 @@ const initializeManaCostsByFunction = theme => {
 };
 
 export const getManaCurveHighchartsSeries = (cards, theme) => {
-  const manaCostsByFaction = initializeManaCostsByFunction(theme);
+  const manaCostsByFaction = initializeManaCostsByFaction(theme);
 
   try {
     Object.values(cards).forEach(c => {

--- a/next/lib/deck-stats.js
+++ b/next/lib/deck-stats.js
@@ -1,21 +1,65 @@
-export const getManaCurve = cards => {
-  const manaCosts = {
-    '1': 0,
-    '2': 0,
-    '3': 0,
-    '4': 0,
-    '5': 0,
-    '6+': 0
-  };
+import { FACTION_NAMES, FACTION_COLORS } from '../constants/factions';
+import { mainFaction } from './card';
+
+const factionMainColor = (faction, theme) => {
+  let color = null;
+  switch (faction) {
+    case FACTION_COLORS.blue:
+      color = theme.blueFactionColor;
+      break;
+    case FACTION_COLORS.yellow:
+      color = theme.yellowFactionColor;
+      break;
+    case FACTION_COLORS.red:
+      color = theme.redFactionColor;
+      break;
+    case FACTION_COLORS.purple:
+      color = theme.purpleFactionColor;
+      break;
+    case FACTION_COLORS.orange:
+      color = theme.orangeFactionColor;
+      break;
+    case FACTION_COLORS.green:
+      color = theme.greenFactionColor;
+      break;
+  }
+
+  return color;
+};
+
+export const getManaCurve = (cards, theme) => {
+  const manaCostsByFaction = {};
+  FACTION_NAMES.forEach(f => {
+    manaCostsByFaction[f] = {
+      name: f,
+      showInLegend: false,
+      color: factionMainColor(f, theme),
+      data: {
+        '1': 0,
+        '2': 0,
+        '3': 0,
+        '4': 0,
+        '5': 0,
+        '6+': 0
+      }
+    };
+  });
 
   try {
-    Object.values(cards).forEach(card => {
-      const manaCost = card.card.mana >= 6 ? '6+' : card.card.mana.toString();
-      manaCosts[manaCost] += card.quantity;
+    Object.values(cards).forEach(c => {
+      const { quantity, card } = c;
+      const primaryFaction = mainFaction(card);
+      const manaCost = card.mana >= 6 ? '6+' : card.mana.toString();
+      manaCostsByFaction[primaryFaction].data[manaCost] += quantity;
     });
   } catch (e) {
     console.error(e);
   }
 
-  return Object.values(manaCosts);
+  const manaCurveSeries = Object.values(manaCostsByFaction).map(f => ({
+    ...f,
+    data: Object.values(f.data)
+  }));
+
+  return manaCurveSeries;
 };

--- a/next/lib/deck-stats.js
+++ b/next/lib/deck-stats.js
@@ -27,10 +27,9 @@ const factionMainColor = (faction, theme) => {
   return color;
 };
 
-export const getManaCurve = (cards, theme) => {
-  const manaCostsByFaction = {};
-  FACTION_NAMES.forEach(f => {
-    manaCostsByFaction[f] = {
+const initializeManaCostsByFunction = theme => {
+  return FACTION_NAMES.reduce((acc, f) => {
+    acc[f] = {
       name: f,
       showInLegend: false,
       color: factionMainColor(f, theme),
@@ -43,7 +42,13 @@ export const getManaCurve = (cards, theme) => {
         '6+': 0
       }
     };
-  });
+
+    return acc;
+  }, {});
+};
+
+export const getManaCurveHighchartsSeries = (cards, theme) => {
+  const manaCostsByFaction = initializeManaCostsByFunction(theme);
 
   try {
     Object.values(cards).forEach(c => {

--- a/next/lib/deck-stats.test.js
+++ b/next/lib/deck-stats.test.js
@@ -1,0 +1,186 @@
+import { getManaCurveHighchartsSeries } from './deck-stats';
+import { FACTION_NAMES } from '../constants/factions';
+
+const createFakeCard = (quantity, mana, factionName) => {
+  return {
+    quantity,
+    card: {
+      mana,
+      cardFactions: {
+        nodes: [
+          {
+            faction: { name: factionName }
+          }
+        ]
+      }
+    }
+  };
+};
+
+describe('Deck stats utility methods', () => {
+  describe('Test getManaCurveHighchartsSeries', () => {
+    const theme = {
+      blueFactionColor: 'blue',
+      yellowFactionColor: 'yellow',
+      redFactionColor: 'red',
+      purpleFactionColor: 'purple',
+      orangeFactionColor: 'orange',
+      greenFactionColor: 'green'
+    };
+
+    it('No cards', function() {
+      const result = getManaCurveHighchartsSeries({}, theme);
+      const expected = [
+        {
+          name: FACTION_NAMES[0],
+          showInLegend: false,
+          color: 'blue',
+          data: [0, 0, 0, 0, 0, 0]
+        },
+        {
+          name: FACTION_NAMES[1],
+          showInLegend: false,
+          color: 'yellow',
+          data: [0, 0, 0, 0, 0, 0]
+        },
+        {
+          name: FACTION_NAMES[2],
+          showInLegend: false,
+          color: 'red',
+          data: [0, 0, 0, 0, 0, 0]
+        },
+        {
+          name: FACTION_NAMES[3],
+          showInLegend: false,
+          color: 'green',
+          data: [0, 0, 0, 0, 0, 0]
+        },
+        {
+          name: FACTION_NAMES[4],
+          showInLegend: false,
+          color: 'orange',
+          data: [0, 0, 0, 0, 0, 0]
+        },
+        {
+          name: FACTION_NAMES[5],
+          showInLegend: false,
+          color: 'purple',
+          data: [0, 0, 0, 0, 0, 0]
+        }
+      ];
+
+      expect(result).toEqual(expected);
+    });
+
+    it('Single faction - all prices present', function() {
+      const cards = {
+        a: createFakeCard(2, 1, FACTION_NAMES[0]),
+        b: createFakeCard(20, 2, FACTION_NAMES[0]),
+        c: createFakeCard(200, 3, FACTION_NAMES[0]),
+        d: createFakeCard(2000, 4, FACTION_NAMES[0]),
+        e: createFakeCard(20000, 5, FACTION_NAMES[0]),
+        f: createFakeCard(200000, 6, FACTION_NAMES[0]),
+        g: createFakeCard(200000, 20, FACTION_NAMES[0])
+      };
+
+      const result = getManaCurveHighchartsSeries(cards, theme);
+      const expected = [
+        {
+          name: FACTION_NAMES[0],
+          showInLegend: false,
+          color: 'blue',
+          data: [2, 20, 200, 2000, 20000, 400000]
+        },
+        {
+          name: FACTION_NAMES[1],
+          showInLegend: false,
+          color: 'yellow',
+          data: [0, 0, 0, 0, 0, 0]
+        },
+        {
+          name: FACTION_NAMES[2],
+          showInLegend: false,
+          color: 'red',
+          data: [0, 0, 0, 0, 0, 0]
+        },
+        {
+          name: FACTION_NAMES[3],
+          showInLegend: false,
+          color: 'green',
+          data: [0, 0, 0, 0, 0, 0]
+        },
+        {
+          name: FACTION_NAMES[4],
+          showInLegend: false,
+          color: 'orange',
+          data: [0, 0, 0, 0, 0, 0]
+        },
+        {
+          name: FACTION_NAMES[5],
+          showInLegend: false,
+          color: 'purple',
+          data: [0, 0, 0, 0, 0, 0]
+        }
+      ];
+
+      expect(result).toEqual(expected);
+    });
+
+    it('Multiple factions, multiple prices', function() {
+      const cards = {
+        a: createFakeCard(2, 1, FACTION_NAMES[0]),
+        b: createFakeCard(3, 2, FACTION_NAMES[0]),
+        c: createFakeCard(5, 6, FACTION_NAMES[0]),
+        d: createFakeCard(10, 4, FACTION_NAMES[1]),
+        e: createFakeCard(3, 5, FACTION_NAMES[2]),
+        f: createFakeCard(20, 5, FACTION_NAMES[2]),
+        g: createFakeCard(8, 1, FACTION_NAMES[2]),
+        h: createFakeCard(10, 10, FACTION_NAMES[3]),
+        i: createFakeCard(5, 2, FACTION_NAMES[4]),
+        j: createFakeCard(6, 1, FACTION_NAMES[5])
+      };
+
+      const result = getManaCurveHighchartsSeries(cards, theme);
+      const expected = [
+        {
+          name: FACTION_NAMES[0],
+          showInLegend: false,
+          color: 'blue',
+          data: [2, 3, 0, 0, 0, 5]
+        },
+        {
+          name: FACTION_NAMES[1],
+          showInLegend: false,
+          color: 'yellow',
+          data: [0, 0, 0, 10, 0, 0]
+        },
+        {
+          name: FACTION_NAMES[2],
+          showInLegend: false,
+          color: 'red',
+          data: [8, 0, 0, 0, 23, 0]
+        },
+        {
+          name: FACTION_NAMES[3],
+          showInLegend: false,
+          color: 'green',
+          data: [0, 0, 0, 0, 0, 10]
+        },
+        {
+          name: FACTION_NAMES[4],
+          showInLegend: false,
+          color: 'orange',
+          data: [0, 5, 0, 0, 0, 0]
+        },
+        {
+          name: FACTION_NAMES[5],
+          showInLegend: false,
+          color: 'purple',
+          data: [6, 0, 0, 0, 0, 0]
+        }
+      ];
+
+      expect(result).toEqual(expected);
+    });
+  });
+});

--- a/next/package.json
+++ b/next/package.json
@@ -31,6 +31,8 @@
     "faker": "^4.1.0",
     "graphql": "^14.5.8",
     "graphql-tag": "^2.10.1",
+    "highcharts": "^7.2.1",
+    "highcharts-react-official": "^2.2.2",
     "isomorphic-unfetch": "^3.0.0",
     "js-cookie": "^2.2.1",
     "jsonwebtoken": "^8.5.1",


### PR DESCRIPTION
- Added highcharts to the project. I have tried others but honestly highcharts still rules.
- Added a deck-stats utility file to create the mana curve series + unit tests
- Added mana curve chart to the deck page under factions
- Added mana curve charts to the deck builder, under the action buttons - if there are any cards
- Tiny e2e tests.

