### PR TITLE
Deck builder plus minus

### DIFF
--- a/express/whitelisted-queries.js
+++ b/express/whitelisted-queries.js
@@ -177,6 +177,7 @@ mutation UpdateDeckAndRemoveCards(
         mana
         gem
         rarity
+        supertype
         cardFactions {
           nodes {
             faction {
@@ -241,6 +242,7 @@ mutation UpdateDeckAndRemoveCards(
           id
           mana
           gem
+          supertype
           cardFactions {
             nodes {
               faction {

--- a/next/components/deck-builder-sidebar.js
+++ b/next/components/deck-builder-sidebar.js
@@ -35,7 +35,7 @@ export default function DeckBuilderSidebar(props) {
     });
   };
 
-  const addSingleCard = card => {
+  const increaseCardQuantity = card => {
     const newMainDeck = { ...deckInProgress.mainDeck };
 
     setDeckInProgress({
@@ -44,7 +44,7 @@ export default function DeckBuilderSidebar(props) {
     });
   };
 
-  const removeSingleCard = card => {
+  const decreaseCardQuantity = card => {
     const newMainDeck = { ...deckInProgress.mainDeck };
 
     setDeckInProgress({
@@ -163,8 +163,8 @@ export default function DeckBuilderSidebar(props) {
             updateDeckName={updateDeckName}
             deck={deckInProgress}
             deleteCard={deleteCardFromTable}
-            addSingleCard={addSingleCard}
-            removeSingleCard={removeSingleCard}
+            increaseCardQuantity={increaseCardQuantity}
+            decreaseCardQuantity={decreaseCardQuantity}
             switchToCards={switchToCards}
             setTab={setTab}
           />

--- a/next/components/deck-builder-sidebar.js
+++ b/next/components/deck-builder-sidebar.js
@@ -5,7 +5,9 @@ import DeckCardTable from '../components/deck-card-table';
 import {
   initializeDeckBuilder,
   resetDeckBuilderSavedState,
-  getCardCount
+  getCardCount,
+  addCardToDeck,
+  removeCardFromDeck
 } from '../lib/deck-utils';
 import { ThemeContext } from './theme-context';
 import DeckBuilderActionButtons from './deck-builder-action-buttons';
@@ -30,6 +32,24 @@ export default function DeckBuilderSidebar(props) {
     setDeckInProgress({
       ...deckInProgress,
       deckName: e.target.value
+    });
+  };
+
+  const addSingleCard = card => {
+    const newMainDeck = { ...deckInProgress.mainDeck };
+
+    setDeckInProgress({
+      ...deckInProgress,
+      mainDeck: addCardToDeck(newMainDeck, card)
+    });
+  };
+
+  const removeSingleCard = card => {
+    const newMainDeck = { ...deckInProgress.mainDeck };
+
+    setDeckInProgress({
+      ...deckInProgress,
+      mainDeck: removeCardFromDeck(newMainDeck, card)
     });
   };
 
@@ -143,6 +163,8 @@ export default function DeckBuilderSidebar(props) {
             updateDeckName={updateDeckName}
             deck={deckInProgress}
             deleteCard={deleteCardFromTable}
+            addSingleCard={addSingleCard}
+            removeSingleCard={removeSingleCard}
             switchToCards={switchToCards}
             setTab={setTab}
           />

--- a/next/components/deck-card-table-row.js
+++ b/next/components/deck-card-table-row.js
@@ -102,8 +102,15 @@ export default function DeckCardsTableRow({
         }
         @media (hover: hover) {
           // Show the hover image (but only on devices that have hover)
+          // and reveal the plus and minus buttons
           .deck-card-name:hover .deck-card-link-container::before,
           .deck-card-name:hover .deck-card-plus-minus {
+            visibility: visible;
+            opacity: 1;
+          }
+        }
+        @media (hover: none) {
+          .deck-card-plus-minus {
             visibility: visible;
             opacity: 1;
           }

--- a/next/components/deck-card-table-row.js
+++ b/next/components/deck-card-table-row.js
@@ -11,8 +11,8 @@ import { SUPERTYPE_IMAGES } from '../constants/supertypes.js';
 export default function DeckCardsTableRow({
   deckCard,
   deleteCard,
-  addSingleCard,
-  removeSingleCard
+  increaseCardQuantity,
+  decreaseCardQuantity
 }) {
   const theme = useContext(ThemeContext);
   const card = deckCard.card;
@@ -113,16 +113,30 @@ export default function DeckCardsTableRow({
       <td className="deck-card-gems">
         <GemDot gems={card.gem} />
       </td>
-      <td className="deck-card-name" style={{ backgroundColor, color }}>
+      <td
+        className="deck-card-name"
+        data-cy="deckCardName"
+        style={{ backgroundColor, color }}
+      >
         <div className="deck-card-link-container">
           <Link href={`/card?id=${card.id}`}>
             <a className="deck-card-link">{card.name}</a>
           </Link>
         </div>
-        {addSingleCard && removeSingleCard && (
+        {increaseCardQuantity && decreaseCardQuantity && (
           <div className="deck-card-plus-minus">
-            <button onClick={() => addSingleCard(deckCard)}>+</button>
-            <button onClick={() => removeSingleCard(deckCard)}>-</button>
+            <button
+              data-cy="deckAddCard"
+              onClick={() => increaseCardQuantity(deckCard)}
+            >
+              +
+            </button>
+            <button
+              data-cy="deckRemoveCard"
+              onClick={() => decreaseCardQuantity(deckCard)}
+            >
+              -
+            </button>
           </div>
         )}
       </td>
@@ -158,8 +172,8 @@ export default function DeckCardsTableRow({
 
 DeckCardsTableRow.propTypes = {
   deleteCard: PropTypes.func,
-  addSingleCard: PropTypes.func,
-  removeSingleCard: PropTypes.func,
+  increaseCardQuantity: PropTypes.func,
+  decreaseCardQuantity: PropTypes.func,
   quantity: PropTypes.number,
   deckCard: PropTypes.shape({
     quantity: PropTypes.number,

--- a/next/components/deck-card-table-row.js
+++ b/next/components/deck-card-table-row.js
@@ -52,8 +52,8 @@ export default function DeckCardsTableRow({ card, deleteCard, quantity }) {
         .deck-card-name::before {
           content: url(${imagePath});
           position: absolute;
-          top: 50%;
-          left: 70%;
+          top: 125%;
+          left: 0;
           z-index: 2;
           visibility: hidden;
           opacity: 0;

--- a/next/components/deck-card-table-row.js
+++ b/next/components/deck-card-table-row.js
@@ -93,7 +93,8 @@ export default function DeckCardsTableRow({
         .deck-card-plus-minus {
           height: calc(100% + 12px);
           display: flex;
-          opacity: 1;
+          visibility: hidden;
+          opacity: 0;
         }
         .deck-card-plus-minus button {
           padding: 0 8px 4px 8px;
@@ -101,11 +102,9 @@ export default function DeckCardsTableRow({
         }
         @media (hover: hover) {
           // Show the hover image (but only on devices that have hover)
-          .deck-card-link-container:hover::before {
+          .deck-card-name:hover .deck-card-link-container::before,
+          .deck-card-name:hover .deck-card-plus-minus {
             visibility: visible;
-            opacity: 1;
-          }
-          .deck-card-plus-minus:hover {
             opacity: 1;
           }
         }

--- a/next/components/deck-card-table-row.js
+++ b/next/components/deck-card-table-row.js
@@ -8,7 +8,13 @@ import { firstLetterUppercase } from '../lib/string-utils';
 import { getRarityColor } from '../constants/rarities';
 import { SUPERTYPE_IMAGES } from '../constants/supertypes.js';
 
-export default function DeckCardsTableRow({ card, deleteCard, quantity }) {
+export default function DeckCardsTableRow({
+  card,
+  deleteCard,
+  addCard,
+  removeCard,
+  quantity
+}) {
   const theme = useContext(ThemeContext);
   const backgroundColor = cardMainColor(card, theme);
   const color = backgroundColor ? theme.cardTableName : 'white';
@@ -19,7 +25,6 @@ export default function DeckCardsTableRow({ card, deleteCard, quantity }) {
     <tr key={card.id} data-cy="deckCardRow">
       <style jsx>{`
         td {
-          padding: 6px;
           border: ${theme.cardTableBorder};
         }
         .deck-card-cost {
@@ -33,6 +38,7 @@ export default function DeckCardsTableRow({ card, deleteCard, quantity }) {
           cursor: pointer;
           text-align: center;
           text-decoration: underline;
+          padding: 0 3px;
         }
         .deck-card-link,
         .deck-card-link:hover,
@@ -44,16 +50,22 @@ export default function DeckCardsTableRow({ card, deleteCard, quantity }) {
           font-size: 0.8em;
         }
         .deck-card-name {
+          display: flex;
+          justify-content: space-between;
+        }
+        .deck-card-link-container {
           position: relative;
           cursor: pointer;
           background-clip: padding-box;
+          width: 100%;
+          padding: 6px 0 6px 6px;
         }
         // bigger version of the image (hidden until hover)
-        .deck-card-name::before {
+        .deck-card-link-container::before {
           content: url(${imagePath});
           position: absolute;
-          top: 125%;
-          left: 0;
+          top: 150%;
+          left: -5%;
           z-index: 2;
           visibility: hidden;
           opacity: 0;
@@ -63,6 +75,7 @@ export default function DeckCardsTableRow({ card, deleteCard, quantity }) {
           background-color: ${theme.cardTableRowQuantityBackground};
           font-size: 0.9em;
           font-style: italic;
+          padding: 0 4px;
         }
         .deck-card-quantity span {
           display: flex;
@@ -76,11 +89,22 @@ export default function DeckCardsTableRow({ card, deleteCard, quantity }) {
           width: 1px;
           padding: 3px;
         }
-
+        .deck-card-plus-minus {
+          height: calc(100% + 12px);
+          display: flex;
+          opacity: 1;
+        }
+        .deck-card-plus-minus button {
+          padding: 0 8px 4px 8px;
+          font-size: 22px;
+        }
         @media (hover: hover) {
           // Show the hover image (but only on devices that have hover)
-          .deck-card-name:hover::before {
+          .deck-card-link-container:hover::before {
             visibility: visible;
+            opacity: 1;
+          }
+          .deck-card-plus-minus:hover {
             opacity: 1;
           }
         }
@@ -90,9 +114,17 @@ export default function DeckCardsTableRow({ card, deleteCard, quantity }) {
         <GemDot gems={card.gem} />
       </td>
       <td className="deck-card-name" style={{ backgroundColor, color }}>
-        <Link href={`/card?id=${card.id}`}>
-          <a className="deck-card-link">{card.name}</a>
-        </Link>
+        <div className="deck-card-link-container">
+          <Link href={`/card?id=${card.id}`}>
+            <a className="deck-card-link">{card.name}</a>
+          </Link>
+        </div>
+        {addCard && removeCard && (
+          <div className="deck-card-plus-minus">
+            <button onClick={() => addCard(card)}>+</button>
+            <button onClick={() => removeCard(card)}>-</button>
+          </div>
+        )}
       </td>
       <td className="deck-card-quantity">
         <span>
@@ -126,6 +158,8 @@ export default function DeckCardsTableRow({ card, deleteCard, quantity }) {
 
 DeckCardsTableRow.propTypes = {
   deleteCard: PropTypes.func,
+  addCard: PropTypes.func,
+  removeCard: PropTypes.func,
   quantity: PropTypes.number,
   card: PropTypes.shape({
     id: PropTypes.number.isRequired,

--- a/next/components/deck-card-table-row.js
+++ b/next/components/deck-card-table-row.js
@@ -9,13 +9,14 @@ import { getRarityColor } from '../constants/rarities';
 import { SUPERTYPE_IMAGES } from '../constants/supertypes.js';
 
 export default function DeckCardsTableRow({
-  card,
+  deckCard,
   deleteCard,
-  addCard,
-  removeCard,
-  quantity
+  addSingleCard,
+  removeSingleCard
 }) {
   const theme = useContext(ThemeContext);
+  const card = deckCard.card;
+  const quantity = deckCard.quantity;
   const backgroundColor = cardMainColor(card, theme);
   const color = backgroundColor ? theme.cardTableName : 'white';
   const imagePath = imagePathSmall(card.name, card.set || undefined);
@@ -119,10 +120,10 @@ export default function DeckCardsTableRow({
             <a className="deck-card-link">{card.name}</a>
           </Link>
         </div>
-        {addCard && removeCard && (
+        {addSingleCard && removeSingleCard && (
           <div className="deck-card-plus-minus">
-            <button onClick={() => addCard(card)}>+</button>
-            <button onClick={() => removeCard(card)}>-</button>
+            <button onClick={() => addSingleCard(deckCard)}>+</button>
+            <button onClick={() => removeSingleCard(deckCard)}>-</button>
           </div>
         )}
       </td>
@@ -158,16 +159,19 @@ export default function DeckCardsTableRow({
 
 DeckCardsTableRow.propTypes = {
   deleteCard: PropTypes.func,
-  addCard: PropTypes.func,
-  removeCard: PropTypes.func,
+  addSingleCard: PropTypes.func,
+  removeSingleCard: PropTypes.func,
   quantity: PropTypes.number,
-  card: PropTypes.shape({
-    id: PropTypes.number.isRequired,
-    name: PropTypes.string.isRequired,
-    mana: PropTypes.number,
-    gem: PropTypes.string,
-    set: PropTypes.string,
-    supertype: PropTypes.array,
-    rarity: PropTypes.string
+  deckCard: PropTypes.shape({
+    quantity: PropTypes.number,
+    card: PropTypes.shape({
+      id: PropTypes.number.isRequired,
+      name: PropTypes.string.isRequired,
+      mana: PropTypes.number,
+      gem: PropTypes.string,
+      set: PropTypes.string,
+      supertype: PropTypes.array,
+      rarity: PropTypes.string
+    })
   })
 };

--- a/next/components/deck-card-table.js
+++ b/next/components/deck-card-table.js
@@ -14,8 +14,8 @@ export default function DeckCardsTable({
   switchToCards,
   setTab,
   updateDeckName,
-  addSingleCard,
-  removeSingleCard
+  increaseCardQuantity,
+  decreaseCardQuantity
 }) {
   const deckCards = deck && Object.values(deck.mainDeck);
   const colspan = deleteCard ? 4 : 3;
@@ -140,8 +140,8 @@ export default function DeckCardsTable({
               key={i}
               deckCard={deckCard}
               deleteCard={deleteCard}
-              addSingleCard={addSingleCard}
-              removeSingleCard={removeSingleCard}
+              increaseCardQuantity={increaseCardQuantity}
+              decreaseCardQuantity={decreaseCardQuantity}
             />
           ))}
         </tbody>
@@ -153,8 +153,8 @@ export default function DeckCardsTable({
 DeckCardsTable.propTypes = {
   onlyTable: PropTypes.bool,
   deleteCard: PropTypes.func,
-  addSingleCard: PropTypes.func,
-  removeSingleCard: PropTypes.func,
+  increaseCardQuantity: PropTypes.func,
+  decreaseCardQuantity: PropTypes.func,
   deck: PropTypes.shape({
     deckName: PropTypes.string,
     deckPath: PropTypes.shape({

--- a/next/components/deck-card-table.js
+++ b/next/components/deck-card-table.js
@@ -13,7 +13,9 @@ export default function DeckCardsTable({
   onlyTable,
   switchToCards,
   setTab,
-  updateDeckName
+  updateDeckName,
+  addSingleCard,
+  removeSingleCard
 }) {
   const deckCards = deck && Object.values(deck.mainDeck);
   const colspan = deleteCard ? 4 : 3;
@@ -136,9 +138,10 @@ export default function DeckCardsTable({
           {sortedCards.map((deckCard, i) => (
             <DeckCardsTableRow
               key={i}
-              card={deckCard.card}
-              quantity={deckCard.quantity}
+              deckCard={deckCard}
               deleteCard={deleteCard}
+              addSingleCard={addSingleCard}
+              removeSingleCard={removeSingleCard}
             />
           ))}
         </tbody>
@@ -150,6 +153,8 @@ export default function DeckCardsTable({
 DeckCardsTable.propTypes = {
   onlyTable: PropTypes.bool,
   deleteCard: PropTypes.func,
+  addSingleCard: PropTypes.func,
+  removeSingleCard: PropTypes.func,
   deck: PropTypes.shape({
     deckName: PropTypes.string,
     deckPath: PropTypes.shape({

--- a/next/components/deck-mana-curve.js
+++ b/next/components/deck-mana-curve.js
@@ -74,5 +74,5 @@ export default function DeckManaCurve({ cards }) {
 }
 
 DeckManaCurve.propTypes = {
-  cards: PropTypes.array
+  cards: PropTypes.object
 };

--- a/next/lib/card-queries.js
+++ b/next/lib/card-queries.js
@@ -54,6 +54,7 @@ export const getCardsQuery = () => {
           id
           mana
           gem
+          supertype
           cardFactions {
             nodes {
               faction {

--- a/next/lib/deck-utils.js
+++ b/next/lib/deck-utils.js
@@ -21,17 +21,42 @@ export const initializeDeckBuilder = () => {
 
 export const addCardToDeck = (deck, card) => {
   const newDeck = { ...deck };
+  const cardId = card.card.id;
 
-  if (!newDeck.hasOwnProperty(card.card.id)) {
-    newDeck[card.card.id] = card;
+  if (!newDeck.hasOwnProperty(cardId)) {
+    newDeck[cardId] = card;
     return newDeck;
   }
 
-  const oldQuantity = newDeck[card.card.id].quantity;
+  const oldQuantity = newDeck[cardId].quantity;
 
-  newDeck[card.card.id] = {
-    ...newDeck[card.card.id],
+  newDeck[cardId] = {
+    ...newDeck[cardId],
     quantity: getQuantity(card.card, oldQuantity, card.quantity)
+  };
+
+  return newDeck;
+};
+
+export const removeCardFromDeck = (deck, card) => {
+  const newDeck = { ...deck };
+  const cardId = card.card.id;
+
+  // Card doesn't exist... what are we even doing here?
+  if (!newDeck.hasOwnProperty(cardId)) {
+    return newDeck;
+  }
+
+  const oldQuantity = newDeck[cardId].quantity;
+
+  if (oldQuantity === 1) {
+    delete newDeck[cardId];
+    return newDeck;
+  }
+
+  newDeck[cardId] = {
+    ...newDeck[cardId],
+    quantity: oldQuantity - 1
   };
 
   return newDeck;

--- a/next/lib/deck-utils.test.js
+++ b/next/lib/deck-utils.test.js
@@ -1,4 +1,9 @@
-import { addCardToDeck, getQuantity, getCardCount } from './deck-utils';
+import {
+  addCardToDeck,
+  removeCardFromDeck,
+  getQuantity,
+  getCardCount
+} from './deck-utils';
 
 describe('Deck utility methods', () => {
   describe('Test addCardToDeck', () => {
@@ -163,7 +168,173 @@ describe('Deck utility methods', () => {
     });
   });
 
-  describe('Test addCardToDeck', () => {
+  describe('Test removeCardFromDeck', () => {
+    it('Card exists', function() {
+      const deck = {
+        1: {
+          quantity: 1,
+          card: {
+            id: 1,
+            name: 'card 1',
+            rarity: 'COMMON'
+          }
+        },
+        2: {
+          quantity: 2,
+          card: {
+            id: 2,
+            name: 'card 2',
+            rarity: 'COMMON'
+          }
+        }
+      };
+
+      const input1 = {
+        quantity: 1,
+        card: {
+          id: 1,
+          name: 'card 1',
+          rarity: 'COMMON'
+        }
+      };
+
+      const input2 = {
+        quantity: 2,
+        card: {
+          id: 2,
+          name: 'card 2',
+          rarity: 'COMMON'
+        }
+      };
+
+      const expected1 = {
+        2: {
+          quantity: 2,
+          card: {
+            id: 2,
+            name: 'card 2',
+            rarity: 'COMMON'
+          }
+        }
+      };
+
+      const expected2 = {
+        2: {
+          quantity: 1,
+          card: {
+            id: 2,
+            name: 'card 2',
+            rarity: 'COMMON'
+          }
+        }
+      };
+
+      const expected3 = {
+        1: {
+          quantity: 1,
+          card: {
+            id: 1,
+            name: 'card 1',
+            rarity: 'COMMON'
+          }
+        },
+        2: {
+          quantity: 1,
+          card: {
+            id: 2,
+            name: 'card 2',
+            rarity: 'COMMON'
+          }
+        }
+      };
+
+      expect(removeCardFromDeck(deck, input1)).toEqual(expected1);
+      expect(removeCardFromDeck(expected1, input2)).toEqual(expected2);
+      expect(removeCardFromDeck(deck, input2)).toEqual(expected3);
+    });
+
+    it("Card doesn't exist", function() {
+      const deck = {
+        3: {
+          quantity: 1,
+          card: {
+            id: 3,
+            name: 'card 1',
+            rarity: 'COMMON'
+          }
+        }
+      };
+
+      const input1 = {
+        quantity: 1,
+        card: {
+          id: 1,
+          name: 'card 1',
+          rarity: 'COMMON'
+        }
+      };
+
+      const input2 = {
+        quantity: 1,
+        card: {
+          id: 2,
+          name: 'card 2',
+          rarity: 'COMMON'
+        }
+      };
+
+      const exptected1 = {
+        3: {
+          quantity: 1,
+          card: {
+            id: 3,
+            name: 'card 1',
+            rarity: 'COMMON'
+          }
+        },
+        1: {
+          quantity: 1,
+          card: {
+            id: 1,
+            name: 'card 1',
+            rarity: 'COMMON'
+          }
+        }
+      };
+
+      const exptected2 = {
+        3: {
+          quantity: 1,
+          card: {
+            id: 3,
+            name: 'card 1',
+            rarity: 'COMMON'
+          }
+        },
+        1: {
+          quantity: 1,
+          card: {
+            id: 1,
+            name: 'card 1',
+            rarity: 'COMMON'
+          }
+        },
+        2: {
+          quantity: 1,
+          card: {
+            id: 2,
+            name: 'card 2',
+            rarity: 'COMMON'
+          }
+        }
+      };
+
+      expect(addCardToDeck(deck, input1)).toEqual(exptected1);
+      expect(addCardToDeck(exptected1, input2)).toEqual(exptected2);
+    });
+  });
+
+  describe('Test getQuantity', () => {
     it('Should return the right quantities depending on the rarity', function() {
       const common = { rarity: 'COMMON' };
       const uncommon = { rarity: 'UNCOMMON' };

--- a/next/lib/queries/all-cards-query.js
+++ b/next/lib/queries/all-cards-query.js
@@ -9,6 +9,7 @@ const cardsQuery = gql`
         mana
         gem
         rarity
+        supertype
         cardFactions {
           nodes {
             faction {

--- a/postgres/init.sql
+++ b/postgres/init.sql
@@ -63,7 +63,7 @@ INSERT INTO mythgard.card (name, rules, subtype, mana, gem, rarity, supertype)
 INSERT INTO mythgard.card (name, rules, subtype, mana, gem, rarity, supertype)
   VALUES ('Common 8', 'rock', 'Earth Enchantment', '1', 'B', 'COMMON', '{ENCHANTMENT}');
 INSERT INTO mythgard.card (name, rules, subtype, mana, gem, rarity, supertype)
-  VALUES ('Common 9', 'rock', 'Earth Enchantment', '1', 'B', 'COMMON', '{ENCHANTMENT}');
+  VALUES ('Common 9 with a really long name', 'rock', 'Earth Enchantment', '1', 'B', 'COMMON', '{ENCHANTMENT}');
 INSERT INTO mythgard.card (name, rules, subtype, mana, gem, rarity, supertype)
   VALUES ('Ghul', 'rock', 'Earth Enchantment', '1', 'R', 'RARE', '{MINION}');
 INSERT INTO mythgard.card (name, rules, subtype, mana, gem, rarity, supertype)


### PR DESCRIPTION
- shows the card type in deck builder (fixes #240)
- adds a plus and minus button on hover for desktop
- adds a plus and minus button permanently on mobile
- adds unit tests. Sadly there is no hover capability in cypress so there's no great way to test this.

Desktop:
![image](https://user-images.githubusercontent.com/4063797/71426419-201da980-2677-11ea-9123-3252c7d6af28.png)

Mobile:
![image](https://user-images.githubusercontent.com/4063797/71426407-fc5a6380-2676-11ea-8905-cf1e615c3692.png)
