### PR TITLE
Deck search by path power

### DIFF
--- a/e2e/cypress/integration/decks-page.js
+++ b/e2e/cypress/integration/decks-page.js
@@ -22,7 +22,9 @@ import {
   deckArchetypePicker,
   deckTypePicker,
   deckSearchDeckArchetype,
-  deckSearchDeckType
+  deckSearchDeckType,
+  deckSearchDeckPath,
+  deckSearchDeckPower
 } from '../page-objects/all';
 
 const cardSearchSelections = `${cardSearch} ${cardSelectionItem}`;
@@ -127,6 +129,44 @@ describe('Decks Page', function() {
     cy.get(deckTypePicker)
       .eq(2)
       .should('contain', 'Gauntlet');
+    cy.get(deckSearchClear).click();
+    cy.get('[data-cy="deckListItem"]').should('have.length', numRecentDecks);
+
+    // search by path
+    // specific path
+    cy.get(deckSearchDeckPath).select('Way of the Black Lotus');
+    cy.get('[data-cy="deckSearchSubmit"]').click();
+    cy.get('[data-cy="deckListItem"]').should('have.length', 3);
+    cy.get(deckSearchDeckPath)
+      .eq(0)
+      .should('contain', 'Way of the Black Lotus');
+    cy.get(deckSearchDeckPath).select('Path Variable');
+    cy.get('[data-cy="deckSearchSubmit"]').click();
+    cy.get('[data-cy="deckListItem"]').should('have.length', 0);
+
+    // any path
+    cy.get(deckSearchDeckPath).select('Any');
+    cy.get('[data-cy="deckSearchSubmit"]').click();
+    cy.get('[data-cy="deckListItem"]').should('have.length', numRecentDecks);
+    cy.get(deckSearchClear).click();
+    cy.get('[data-cy="deckListItem"]').should('have.length', numRecentDecks);
+
+    // search by power
+    // specific power
+    cy.get(deckSearchDeckPower).select("It's over 9000!!");
+    cy.get('[data-cy="deckSearchSubmit"]').click();
+    cy.get('[data-cy="deckListItem"]').should('have.length', 3);
+    cy.get(deckSearchDeckPower)
+      .eq(0)
+      .should('contain', "It's over 9000!!");
+    cy.get(deckSearchDeckPower).select('Power Rangers');
+    cy.get('[data-cy="deckSearchSubmit"]').click();
+    cy.get('[data-cy="deckListItem"]').should('have.length', 0);
+
+    // any path
+    cy.get(deckSearchDeckPower).select('Any');
+    cy.get('[data-cy="deckSearchSubmit"]').click();
+    cy.get('[data-cy="deckListItem"]').should('have.length', numRecentDecks);
     cy.get(deckSearchClear).click();
     cy.get('[data-cy="deckListItem"]').should('have.length', numRecentDecks);
 

--- a/e2e/cypress/page-objects/all.js
+++ b/e2e/cypress/page-objects/all.js
@@ -50,6 +50,8 @@ export default {
   deckSearchAllDecksLoaded: dcy('all-decks-loaded'),
   deckArchetypePicker: dcy('deckArchetypeCell'),
   deckTypePicker: dcy('deckTypeCell'),
+  deckSearchDeckPath: dcy('deckSearchPath'),
+  deckSearchDeckPower: dcy('deckSearchPower'),
 
   // decks page sorted data
   // used so cypress can know when newly sorted dom is loaded.

--- a/express/whitelisted-queries.js
+++ b/express/whitelisted-queries.js
@@ -7,6 +7,8 @@ const deckPreviewsFragment = `
     votes
     deckArchetype
     deckType
+    pathName
+    powerName
     views
     deck{
       id
@@ -310,6 +312,8 @@ mutation UpdateDeckAndRemoveCards(
         votes
         deckArchetype
         deckType
+        pathName
+        powerName
       }
     }
   }

--- a/express/whitelisted-queries.js
+++ b/express/whitelisted-queries.js
@@ -412,6 +412,8 @@ mutation UpdateDeckAndRemoveCards(
       $numFactions: Int
       $archetype: [Deckarchetype]
       $type: [Decktype]
+      $pathName: String
+      $powerName: String
       $first: Int
       $offset: Int
       $sortBy: String
@@ -434,6 +436,8 @@ mutation UpdateDeckAndRemoveCards(
         numfactions: $numFactions
         archetypefilter: $archetype
         typefilter: $type
+        pathname: $pathName
+        powername: $powerName
         first: $first
         offset: $offset
         sortby: $sortBy
@@ -691,6 +695,22 @@ mutation addFeaturedDeck($deckId: Int!) {
     ) {
       ${deckPreviewsFragment}
       totalCount
+    }
+  }
+`,
+  `
+  query pathPowerQuery {
+    paths {
+      nodes {
+        id
+        name
+      }
+    }
+    powers {
+      nodes {
+        id
+        name
+      }
     }
   }
 `,

--- a/next/components/deck-card-table-edit-meta.js
+++ b/next/components/deck-card-table-edit-meta.js
@@ -1,4 +1,5 @@
 import PropTypes from 'prop-types';
+import PathPowerIconContainer from './path-power-icon-container';
 
 export default function DeckCardsTableEditMeta(props) {
   const { metaName, metaValue, onEditClick, showEdit, icon } = props;
@@ -35,11 +36,7 @@ export default function DeckCardsTableEditMeta(props) {
         }
       `}</style>
       <div className={className} data-cy="deckBuilderMetaValue">
-        {icon && (
-          <div className="icon-container">
-            <img src={icon} />
-          </div>
-        )}
+        <PathPowerIconContainer icon={icon} />
         {metaValue || `No ${metaName} selected`}
       </div>
       {showEdit && (

--- a/next/components/deck-card-table-edit-meta.js
+++ b/next/components/deck-card-table-edit-meta.js
@@ -36,7 +36,7 @@ export default function DeckCardsTableEditMeta(props) {
         }
       `}</style>
       <div className={className} data-cy="deckBuilderMetaValue">
-        <PathPowerIconContainer icon={icon} />
+        <PathPowerIconContainer icon={icon} name={metaValue} />
         {metaValue || `No ${metaName} selected`}
       </div>
       {showEdit && (

--- a/next/components/deck-card-table-edit-meta.js
+++ b/next/components/deck-card-table-edit-meta.js
@@ -25,15 +25,6 @@ export default function DeckCardsTableEditMeta(props) {
         .no-meta-value {
           text-transform: uppercase;
         }
-        .icon-container {
-          width: 20px;
-          height: 20px;
-          margin-right: 5px;
-        }
-        img {
-          width: 20px;
-          height: auto;
-        }
       `}</style>
       <div className={className} data-cy="deckBuilderMetaValue">
         <PathPowerIconContainer icon={icon} name={metaValue} />

--- a/next/components/deck-card-table.js
+++ b/next/components/deck-card-table.js
@@ -6,8 +6,8 @@ import DeckCardsTableRow from './deck-card-table-row';
 import DeckCardsTableEditMeta from './deck-card-table-edit-meta';
 import EditDeckName from './edit-deck-name';
 import DeckBuilderUser from './deck-builder-user';
-import { matchPathNameToIcon } from '../constants/paths';
-import { matchPowerNameToIcon } from '../constants/powers';
+import { matchPathToIcon } from '../constants/paths';
+import { matchPowerToIcon } from '../constants/powers';
 
 export default function DeckCardsTable({
   deck,
@@ -116,7 +116,7 @@ export default function DeckCardsTable({
                 metaName="path"
                 showEdit={!onlyTable}
                 metaValue={deck.deckPath && deck.deckPath.name}
-                icon={matchPathNameToIcon(deck.deckPath)}
+                icon={matchPathToIcon(deck.deckPath)}
                 onEditClick={() => {
                   setTab('Paths');
                   switchToCards();
@@ -131,7 +131,7 @@ export default function DeckCardsTable({
                 metaName="power"
                 showEdit={!onlyTable}
                 metaValue={deck.deckPower && deck.deckPower.name}
-                icon={matchPowerNameToIcon(deck.deckPower)}
+                icon={matchPowerToIcon(deck.deckPower)}
                 onEditClick={() => {
                   setTab('Powers');
                   switchToCards();

--- a/next/components/deck-list.js
+++ b/next/components/deck-list.js
@@ -9,6 +9,9 @@ import UpvoteIndicator from './upvote-indicator.js';
 import { getArchetypeLabel, getTypeLabel } from '../lib/deck-utils';
 import AuthorLink from './author-link';
 import UserAvatar from './user-avatar';
+import PathPowerIconContainer from './path-power-icon-container';
+import { matchPathNameToIcon } from '../constants/paths';
+import { matchPowerNameToIcon } from '../constants/powers';
 
 export default function DeckList({ decks }) {
   const theme = useContext(ThemeContext);
@@ -39,8 +42,16 @@ export default function DeckList({ decks }) {
         .modifiedDate span {
           float: right;
         }
+        .path-power {
+          display: flex;
+          justify-content: center;
+        }
+        .path {
+          padding-right: 10px;
+        }
         .factions {
           text-align: center;
+          padding-bottom: 10px;
         }
         .archetype {
           font-weight: 600;
@@ -96,8 +107,24 @@ export default function DeckList({ decks }) {
                 <td className="deckVotes">
                   <UpvoteIndicator votes={deck.votes || 0} />
                 </td>
-                <td className="factions" data-cy="deckFactionsCell">
-                  <FactionsIndicator factions={deck.factions} />
+                <td className="factions-path-power">
+                  <div className="factions" data-cy="deckFactionsCell">
+                    <FactionsIndicator factions={deck.factions} />
+                  </div>
+                  <div className="path-power" data-cy="deckPathPowerCell">
+                    <div className="path">
+                      <PathPowerIconContainer
+                        large
+                        icon={matchPathNameToIcon(deck.pathName)}
+                      />
+                    </div>
+                    <div className="power">
+                      <PathPowerIconContainer
+                        large
+                        icon={matchPowerNameToIcon(deck.powerName)}
+                      />
+                    </div>
+                  </div>
                 </td>
                 <td className="archetype-type-column">
                   <div className="archetype" data-cy="deckArchetypeCell">

--- a/next/components/deck-list.js
+++ b/next/components/deck-list.js
@@ -115,12 +115,14 @@ export default function DeckList({ decks }) {
                     <div className="path">
                       <PathPowerIconContainer
                         large
+                        name={deck.pathName}
                         icon={matchPathNameToIcon(deck.pathName)}
                       />
                     </div>
                     <div className="power">
                       <PathPowerIconContainer
                         large
+                        name={deck.powerName}
                         icon={matchPowerNameToIcon(deck.powerName)}
                       />
                     </div>

--- a/next/components/deck-search-form.js
+++ b/next/components/deck-search-form.js
@@ -214,6 +214,7 @@ export default function DeckSearchForm(props) {
             )}
             onSubmit={handleSubmit}
           />
+          <div>Path Selector Placeholder</div>
         </div>
         <div className="filter-column">
           <DeckSearchFormUpdated
@@ -228,6 +229,7 @@ export default function DeckSearchForm(props) {
             Includes cards
             {cardSearchElement}
           </label>
+          <div>Power Selector Placeholder</div>
         </div>
         <div className="filter-column">
           <DeckSearchFormDropdownFilter

--- a/next/components/deck-search-form.js
+++ b/next/components/deck-search-form.js
@@ -7,10 +7,9 @@ import CardSearch from './card-search';
 import SearchFormText from './search-form-text';
 import DeckSearchFormUpdated from './deck-search-form-updated';
 import DeckSearchFormSort from './deck-search-form-sort.js';
-import { ARCHETYPES, PATHS, POWERS, TYPES } from '../constants/deck';
+import { ARCHETYPES, TYPES } from '../constants/deck';
 import DeckSearchFormDropdownFilter from './deck-search-form-dropdown-filter.js';
 import { pathPowerQuery } from '../lib/deck-queries.js';
-import ErrorMessage from './error-message.js';
 
 const resetFilters = values => {
   return {

--- a/next/components/path-power-icon-container.js
+++ b/next/components/path-power-icon-container.js
@@ -1,0 +1,34 @@
+import PropTypes from 'prop-types';
+
+export default function PathPowerIconContainer({ icon, large = false }) {
+  if (!icon) return null;
+
+  return (
+    <div className={`icon-container ${large && 'large'}`}>
+      <style jsx>{`
+        .icon-container {
+          width: 20px;
+          height: 20px;
+          margin-right: 5px;
+        }
+        .large {
+          width: 25px;
+          height: 25px;
+        }
+        img {
+          width: 20px;
+          height: auto;
+        }
+        .large img {
+          width: 25px;
+        }
+      `}</style>
+      <img src={icon} />
+    </div>
+  );
+}
+
+PathPowerIconContainer.propTypes = {
+  icon: PropTypes.string,
+  large: PropTypes.bool
+};

--- a/next/components/path-power-icon-container.js
+++ b/next/components/path-power-icon-container.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 
-export default function PathPowerIconContainer({ icon, large = false }) {
+export default function PathPowerIconContainer({ icon, name, large = false }) {
   if (!icon) return null;
 
   return (
@@ -23,7 +23,7 @@ export default function PathPowerIconContainer({ icon, large = false }) {
           width: 25px;
         }
       `}</style>
-      <img src={icon} />
+      <img title={name} aria-label={name} src={icon} />
     </div>
   );
 }

--- a/next/components/path-power-icon-container.js
+++ b/next/components/path-power-icon-container.js
@@ -30,5 +30,6 @@ export default function PathPowerIconContainer({ icon, name, large = false }) {
 
 PathPowerIconContainer.propTypes = {
   icon: PropTypes.string,
+  name: PropTypes.string,
   large: PropTypes.bool
 };

--- a/next/components/some-decks.js
+++ b/next/components/some-decks.js
@@ -36,6 +36,8 @@ const serializeDeckSearchResults = decks => {
     const username = author && author.username;
     const accountType = author && author.accountType;
     const profileIconId = author && author.profileIconId;
+    const pathName = deckPreview && deckPreview.pathName;
+    const powerName = deckPreview && deckPreview.powerName;
 
     return {
       deckId: deck.id,
@@ -49,7 +51,9 @@ const serializeDeckSearchResults = decks => {
       essenceCost,
       votes,
       deckArchetype,
-      deckType
+      deckType,
+      pathName,
+      powerName
     };
   });
 };

--- a/next/components/some-decks.js
+++ b/next/components/some-decks.js
@@ -69,6 +69,8 @@ export default function SomeDecks(props) {
     isOnlyFactions,
     archetype,
     type,
+    pathName,
+    powerName,
     sortBy
   } = props.search;
   const archetypeValue = findValueFromLabel(ARCHETYPES, archetype);
@@ -83,6 +85,8 @@ export default function SomeDecks(props) {
       isOnlyFactions,
       archetype: archetypeValue,
       type: typeValue,
+      pathName,
+      powerName,
       sortBy,
       first: pageSize,
       offset: currentPage * pageSize

--- a/next/constants/paths.js
+++ b/next/constants/paths.js
@@ -8,9 +8,10 @@ const pathIcons = {
   'turn of seasons': `${cdn}TurnOfSeasons.png`
 };
 
-export const matchPathNameToIcon = path => {
+export const matchPathToIcon = path => matchPathNameToIcon(path && path.name);
+
+export const matchPathNameToIcon = pathName => {
   try {
-    const pathName = path.name;
     const lowerCaseName = pathName.toLowerCase();
     return pathIcons[lowerCaseName] || null;
   } catch (e) {

--- a/next/constants/powers.js
+++ b/next/constants/powers.js
@@ -10,12 +10,14 @@ const powerIcons = {
   smite: `${cdn}smite_slug.png`
 };
 
-export const matchPowerNameToIcon = power => {
+export const matchPowerNameToIcon = powerName => {
   try {
-    const powerName = power.name;
     const lowerCaseName = powerName.toLowerCase();
     return powerIcons[lowerCaseName] || null;
   } catch (e) {
     return null;
   }
 };
+
+export const matchPowerToIcon = power =>
+  matchPowerNameToIcon(power && power.name);

--- a/next/constants/powers.js
+++ b/next/constants/powers.js
@@ -10,6 +10,9 @@ const powerIcons = {
   smite: `${cdn}smite_slug.png`
 };
 
+export const matchPowerToIcon = power =>
+  matchPowerNameToIcon(power && power.name);
+
 export const matchPowerNameToIcon = powerName => {
   try {
     const lowerCaseName = powerName.toLowerCase();
@@ -18,6 +21,3 @@ export const matchPowerNameToIcon = powerName => {
     return null;
   }
 };
-
-export const matchPowerToIcon = power =>
-  matchPowerNameToIcon(power && power.name);

--- a/next/lib/deck-queries.js
+++ b/next/lib/deck-queries.js
@@ -11,6 +11,8 @@ const deckPreviewsFragment = `
       votes
       deckArchetype
       deckType
+      pathName
+      powerName
       views
       deck{
         id
@@ -209,6 +211,8 @@ export const allDecksQuery = gql`
         votes
         deckArchetype
         deckType
+        pathName
+        powerName
       }
     }
   }

--- a/next/lib/deck-queries.js
+++ b/next/lib/deck-queries.js
@@ -82,6 +82,8 @@ export const getDeckSearchVars = vars => {
     authorName: vars.authorName,
     archetype: vars.archetype,
     type: vars.type,
+    pathName: vars.pathName,
+    powerName: vars.powerName,
     sortBy: vars.sortBy,
     deckModified: daysAgoToGraphQLTimestamp(vars.updatedTime),
     ...cardIdsToVars(vars.cardIds),
@@ -109,6 +111,8 @@ const deckSearchQuery = gql`
       $numFactions: Int
       $archetype: [Deckarchetype]
       $type: [Decktype]
+      $pathName: String
+      $powerName: String
       $first: Int
       $offset: Int
       $sortBy: String
@@ -131,6 +135,8 @@ const deckSearchQuery = gql`
         numfactions: $numFactions
         archetypefilter: $archetype
         typefilter: $type
+        pathname: $pathName
+        powername: $powerName
         first: $first
         offset: $offset
         sortby: $sortBy
@@ -380,6 +386,23 @@ export const addFeaturedDeckMutation = gql`
       deckFeatured {
         deckId
         id
+      }
+    }
+  }
+`;
+
+export const pathPowerQuery = gql`
+  query pathPowerQuery {
+    paths {
+      nodes {
+        id
+        name
+      }
+    }
+    powers {
+      nodes {
+        id
+        name
       }
     }
   }

--- a/next/pages/decks.js
+++ b/next/pages/decks.js
@@ -23,8 +23,8 @@ const searchQueryDefaults = {
   updatedTime: defaultUpdatedTime,
   authorName: '',
   sortBy: 'hot',
-  pathName: '',
-  powerName: ''
+  pathName: null,
+  powerName: null
 };
 
 const cardsErr = 'Error initializing deck search';

--- a/next/pages/decks.js
+++ b/next/pages/decks.js
@@ -22,7 +22,9 @@ const searchQueryDefaults = {
   type: null,
   updatedTime: defaultUpdatedTime,
   authorName: '',
-  sortBy: 'hot'
+  sortBy: 'hot',
+  pathName: '',
+  powerName: ''
 };
 
 const cardsErr = 'Error initializing deck search';

--- a/postgres/init.sql
+++ b/postgres/init.sql
@@ -720,6 +720,8 @@ CREATE INDEX author_name_index ON mythgard.account
 -- numFactions int or null - number of specified factions. Omit to allow more factions than specifed.
 -- archetype   mythgard.deckArchetype or null - array of archetypes to filter by
 -- type        mythgard.deckType or null - array of types to filter by
+-- pathName    mythgard.path.name or null - path to filter by
+-- powerName   mythgard.power.name or null - power to filter by
 create or replace function mythgard.search_decks_nosort(
   deckName varchar(255),
   authorName varchar(255),
@@ -737,13 +739,17 @@ create or replace function mythgard.search_decks_nosort(
   faction6 integer,
   numFactions integer,
   archetypeFilter mythgard.deckArchetype[],
-  typeFilter mythgard.deckType[])
+  typeFilter mythgard.deckType[],
+  pathName varchar(255),
+  powerName varchar(255))
   returns setof mythgard.deck as $$
 
     SELECT deck.* FROM mythgard.deck
       LEFT JOIN mythgard.card_deck ON (card_deck.deck_id = deck.id)
       LEFT JOIN mythgard.card ON (card.id = card_deck.card_id)
       LEFT JOIN mythgard.account ON (account.id = deck.author_id)
+      LEFT JOIN mythgard.path ON (path.id = deck.path_id)
+      LEFT JOIN mythgard.power ON (power.id = deck.power_id)
 
     -- deck name filter
     WHERE (deckName is NULL or trim(deckName) = '' or to_tsvector('simple', deck.name) @@ to_tsquery('simple', replace(regexp_replace(trim(deckName), '\s+', ' ', 'g'), ' ', ':* & ') || ':*'))
@@ -755,6 +761,10 @@ create or replace function mythgard.search_decks_nosort(
     AND (archetypeFilter is NULL or deck.archetype = archetypeFilter)
     -- type filter
     AND (typeFilter is NULL or deck.type = typeFilter)
+    -- path filter
+    AND (pathName is NULL or path.name = pathName)
+    -- power filter
+    AND (powerName is NULL or power.name = powerName)
 
     intersect
 
@@ -821,6 +831,8 @@ create or replace function mythgard.search_decks(
   numFactions integer,
   archetypeFilter mythgard.deckArchetype[],
   typeFilter mythgard.deckType[],
+  pathName varchar(255),
+  powerName varchar(255),
   sortBy text)
   returns setof mythgard.deck as $$
 
@@ -829,20 +841,20 @@ create or replace function mythgard.search_decks(
         RETURN QUERY select id, name, author_id, path_id, power_id, modified, created, description, archetype, type
           from ( select * from mythgard.search_decks_nosort(deckName, authorName, deckModified, card1,
                   card2, card3, card4, card5, faction1, faction2, faction3, faction4, faction5,
-                  faction6, numFactions, archetypeFilter, typeFilter) as foo,
+                  faction6, numFactions, archetypeFilter, typeFilter, pathName, powerName) as foo,
                   mythgard.deck_essence_cost(foo.id) as dec
                   order by dec desc nulls last) as bar;
        ELSIF sortBy = 'essenceAsc' THEN
         RETURN QUERY select id, name, author_id, path_id, power_id, modified, created, description, archetype, type
           from ( select * from mythgard.search_decks_nosort(deckName, authorName, deckModified, card1,
                   card2, card3, card4, card5, faction1, faction2, faction3, faction4, faction5,
-                  faction6, numFactions, archetypeFilter, typeFilter) as foo,
+                  faction6, numFactions, archetypeFilter, typeFilter, pathName, powerName) as foo,
                   mythgard.deck_essence_cost(foo.id) as dec
                   order by dec asc nulls last) as bar;
        ELSIF sortBy = 'ratingDesc' THEN
         RETURN QUERY select deck.* from mythgard.search_decks_nosort(deckName, authorName, deckModified, card1,
                   card2, card3, card4, card5, faction1, faction2, faction3, faction4, faction5,
-                  faction6, numFactions, archetypeFilter, typeFilter) as deck
+                  faction6, numFactions, archetypeFilter, typeFilter, pathName, powerName) as deck
           LEFT JOIN
           (SELECT count(*) as voteCount, deck_id from mythgard.deck_vote group by deck_id) as deckVotes
           on deckVotes.deck_id = deck.id
@@ -851,7 +863,7 @@ create or replace function mythgard.search_decks(
        ELSIF sortBy = 'ratingAsc' THEN
         RETURN QUERY select deck.* from mythgard.search_decks_nosort(deckName, authorName, deckModified, card1,
                   card2, card3, card4, card5, faction1, faction2, faction3, faction4, faction5,
-                  faction6, numFactions, archetypeFilter, typeFilter) as deck
+                  faction6, numFactions, archetypeFilter, typeFilter, pathName, powerName) as deck
           LEFT JOIN
           (SELECT count(*) as voteCount, deck_id from mythgard.deck_vote group by deck_id) as deckVotes
           on deckVotes.deck_id = deck.id
@@ -860,27 +872,27 @@ create or replace function mythgard.search_decks(
        ELSIF sortBy = 'nameAsc' THEN
          RETURN QUERY select * from mythgard.search_decks_nosort(deckName, authorName, deckModified, card1,
                   card2, card3, card4, card5, faction1, faction2, faction3, faction4, faction5,
-                  faction6, numFactions, archetypeFilter, typeFilter) order by lower(name) asc;
+                  faction6, numFactions, archetypeFilter, typeFilter, pathName, powerName) order by lower(name) asc;
        ELSIF sortBy = 'nameDesc' THEN
          RETURN QUERY select * from mythgard.search_decks_nosort(deckName, authorName, deckModified, card1,
                   card2, card3, card4, card5, faction1, faction2, faction3, faction4, faction5,
-                  faction6, numFactions, archetypeFilter, typeFilter) order by lower(name) desc;
+                  faction6, numFactions, archetypeFilter, typeFilter, pathName, powerName) order by lower(name) desc;
        ELSIF sortBy = 'dateDesc' THEN
          RETURN QUERY select * from mythgard.search_decks_nosort(deckName, authorName, deckModified, card1,
                   card2, card3, card4, card5, faction1, faction2, faction3, faction4, faction5,
-                  faction6, numFactions, archetypeFilter, typeFilter) order by created desc;
+                  faction6, numFactions, archetypeFilter, typeFilter, pathName, powerName) order by created desc;
        ELSIF sortBy = 'dateAsc' THEN
          RETURN QUERY select * from mythgard.search_decks_nosort(deckName, authorName, deckModified, card1,
                   card2, card3, card4, card5, faction1, faction2, faction3, faction4, faction5,
-                  faction6, numFactions, archetypeFilter, typeFilter) order by created asc;
+                  faction6, numFactions, archetypeFilter, typeFilter, pathName, powerName) order by created asc;
        ELSIF sortBy = 'hot' THEN
          RETURN QUERY select * from mythgard.search_decks_nosort(deckName, authorName, deckModified, card1,
                   card2, card3, card4, card5, faction1, faction2, faction3, faction4, faction5,
-                  faction6, numFactions, archetypeFilter, typeFilter) order by mythgard.deck_hotness(id) desc;
+                  faction6, numFactions, archetypeFilter, typeFilter, pathName, powerName) order by mythgard.deck_hotness(id) desc;
        ELSE
           RETURN QUERY select * from mythgard.search_decks_nosort(deckName, authorName, deckModified, card1,
                   card2, card3, card4, card5, faction1, faction2, faction3, faction4, faction5,
-                  faction6, numFactions, archetypeFilter, typeFilter);
+                  faction6, numFactions, archetypeFilter, typeFilter, pathName, powerName);
        END IF;
        RETURN;
    END

--- a/postgres/init.sql
+++ b/postgres/init.sql
@@ -668,12 +668,18 @@ CREATE OR REPLACE VIEW mythgard.deck_preview as
          account.account_type as account_type,
          account.profile_icon_id as profile_icon_id,
          mythgard.deck_hotness(deck.id)::int as hotness,
-         deck_views.views::int as views
+         deck_views.views::int as views,
+         path.name as path_name,
+         power.name as power_name
   FROM mythgard.deck
   LEFT JOIN mythgard.account
   ON mythgard.account.id = mythgard.deck.author_id
   LEFT JOIN mythgard.deck_views
   ON mythgard.deck_views.deck_id = mythgard.deck.id
+  LEFT JOIN mythgard.path
+  ON mythgard.path.id = mythgard.deck.path_id
+  LEFT JOIN mythgard.power
+  ON mythgard.power.id = mythgard.deck.power_id
 ;
 
 -- See https://www.graphile.org/postgraphile/smart-comments/#foreign-key

--- a/postgres/migrations/next-migration.sql
+++ b/postgres/migrations/next-migration.sql
@@ -26,3 +26,184 @@ CREATE OR REPLACE VIEW mythgard.deck_preview as
   LEFT JOIN mythgard.power
   ON mythgard.power.id = mythgard.deck.power_id
 ;
+
+drop function mythgard.search_decks_nosort;
+
+create or replace function mythgard.search_decks_nosort(
+  deckName varchar(255),
+  authorName varchar(255),
+  deckModified date,
+  card1 integer,
+  card2 Integer,
+  card3 Integer,
+  card4 Integer,
+  card5 Integer,
+  faction1 integer,
+  faction2 integer,
+  faction3 integer,
+  faction4 integer,
+  faction5 integer,
+  faction6 integer,
+  numFactions integer,
+  archetypeFilter mythgard.deckArchetype[],
+  typeFilter mythgard.deckType[],
+  pathName varchar(255),
+  powerName varchar(255))
+  returns setof mythgard.deck as $$
+
+    SELECT deck.* FROM mythgard.deck
+      LEFT JOIN mythgard.card_deck ON (card_deck.deck_id = deck.id)
+      LEFT JOIN mythgard.card ON (card.id = card_deck.card_id)
+      LEFT JOIN mythgard.account ON (account.id = deck.author_id)
+      LEFT JOIN mythgard.path ON (path.id = deck.path_id)
+      LEFT JOIN mythgard.power ON (power.id = deck.power_id)
+
+    -- deck name filter
+    WHERE (deckName is NULL or trim(deckName) = '' or to_tsvector('simple', deck.name) @@ to_tsquery('simple', replace(regexp_replace(trim(deckName), '\s+', ' ', 'g'), ' ', ':* & ') || ':*'))
+    -- author name filter
+    AND (authorName is NULL or trim(authorName) = '' or to_tsvector('simple', account.username) @@ to_tsquery('simple', replace(regexp_replace(trim(authorName), '\s+', ' ', 'g'), ' ', ':* & ') || ':*'))
+    -- modification date filter
+    AND (deckModified is NULL or deck.modified >= deckModified)
+    -- archetype filter
+    AND (archetypeFilter is NULL or deck.archetype = archetypeFilter)
+    -- type filter
+    AND (typeFilter is NULL or deck.type = typeFilter)
+    -- path filter
+    AND (pathName is NULL or path.name = pathName)
+    -- power filter
+    AND (powerName is NULL or power.name = powerName)
+
+    intersect
+
+    -- cards filter
+    SELECT deck.* from mythgard.deck left join mythgard.card_deck on (deck.id = card_deck.deck_id) left join mythgard.card on (card.id = card_deck.card_id) left join mythgard.card_faction on (card.id = card_faction.card_id)
+    where card1 is null or card.id = card1
+    intersect
+    SELECT deck.* from mythgard.deck left join mythgard.card_deck on (deck.id = card_deck.deck_id) left join mythgard.card on (card.id = card_deck.card_id) left join mythgard.card_faction on (card.id = card_faction.card_id)
+    where card2 is null or card.id = card2
+    intersect
+    SELECT deck.* from mythgard.deck left join mythgard.card_deck on (deck.id = card_deck.deck_id) left join mythgard.card on (card.id = card_deck.card_id) left join mythgard.card_faction on (card.id = card_faction.card_id)
+    where card3 is null or card.id = card3
+    intersect
+    SELECT deck.* from mythgard.deck left join mythgard.card_deck on (deck.id = card_deck.deck_id) left join mythgard.card on (card.id = card_deck.card_id) left join mythgard.card_faction on (card.id = card_faction.card_id)
+    where card4 is null or card.id = card4
+    intersect
+    SELECT deck.* from mythgard.deck left join mythgard.card_deck on (deck.id = card_deck.deck_id) left join mythgard.card on (card.id = card_deck.card_id) left join mythgard.card_faction on (card.id = card_faction.card_id)
+    where card5 is null or card.id = card5
+
+    intersect
+
+    -- factions filter
+    SELECT deck.* from mythgard.deck left join mythgard.card_deck on (deck.id = card_deck.deck_id) left join mythgard.card on (card.id = card_deck.card_id) left join mythgard.card_faction on (card.id = card_faction.card_id) left join mythgard.faction on (faction.id = card_faction.faction_id)
+    group by deck.id
+    having numFactions is NULL or numFactions = 0 or count(distinct faction.id) = numFactions
+    intersect
+    SELECT deck.* from mythgard.deck left join mythgard.card_deck on (deck.id = card_deck.deck_id) left join mythgard.card on (card.id = card_deck.card_id) left join mythgard.card_faction on (card.id = card_faction.card_id) left join mythgard.faction on (faction.id = card_faction.faction_id)
+    where faction1 is null or faction.id = faction1
+    intersect
+    SELECT deck.* from mythgard.deck left join mythgard.card_deck on (deck.id = card_deck.deck_id) left join mythgard.card on (card.id = card_deck.card_id) left join mythgard.card_faction on (card.id = card_faction.card_id) left join mythgard.faction on (faction.id = card_faction.faction_id)
+    where faction2 is null or faction.id = faction2
+    intersect
+    SELECT deck.* from mythgard.deck left join mythgard.card_deck on (deck.id = card_deck.deck_id) left join mythgard.card on (card.id = card_deck.card_id) left join mythgard.card_faction on (card.id = card_faction.card_id) left join mythgard.faction on (faction.id = card_faction.faction_id)
+    where faction3 is null or faction.id = faction3
+    intersect
+    SELECT deck.* from mythgard.deck left join mythgard.card_deck on (deck.id = card_deck.deck_id) left join mythgard.card on (card.id = card_deck.card_id) left join mythgard.card_faction on (card.id = card_faction.card_id) left join mythgard.faction on (faction.id = card_faction.faction_id)
+    where faction4 is null or faction.id = faction4
+    intersect
+    SELECT deck.* from mythgard.deck left join mythgard.card_deck on (deck.id = card_deck.deck_id) left join mythgard.card on (card.id = card_deck.card_id) left join mythgard.card_faction on (card.id = card_faction.card_id) left join mythgard.faction on (faction.id = card_faction.faction_id)
+    where faction5 is null or faction.id = faction5
+    intersect
+    SELECT deck.* from mythgard.deck left join mythgard.card_deck on (deck.id = card_deck.deck_id) left join mythgard.card on (card.id = card_deck.card_id) left join mythgard.card_faction on (card.id = card_faction.card_id) left join mythgard.faction on (faction.id = card_faction.faction_id)
+    where faction6 is null or faction.id = faction6
+
+    GROUP BY deck.id
+    LIMIT 2000;
+  $$ language sql stable;
+
+drop function mythgard.search_decks;
+
+create or replace function mythgard.search_decks(
+  deckName varchar(255),
+  authorName varchar(255),
+  deckModified date,
+  card1 integer,
+  card2 Integer,
+  card3 Integer,
+  card4 Integer,
+  card5 Integer,
+  faction1 integer,
+  faction2 integer,
+  faction3 integer,
+  faction4 integer,
+  faction5 integer,
+  faction6 integer,
+  numFactions integer,
+  archetypeFilter mythgard.deckArchetype[],
+  typeFilter mythgard.deckType[],
+  pathName varchar(255),
+  powerName varchar(255),
+  sortBy text)
+  returns setof mythgard.deck as $$
+
+  BEGIN
+       IF sortBy = 'essenceDesc' THEN
+        RETURN QUERY select id, name, author_id, path_id, power_id, modified, created, description, archetype, type
+          from ( select * from mythgard.search_decks_nosort(deckName, authorName, deckModified, card1,
+                  card2, card3, card4, card5, faction1, faction2, faction3, faction4, faction5,
+                  faction6, numFactions, archetypeFilter, typeFilter, pathName, powerName) as foo,
+                  mythgard.deck_essence_cost(foo.id) as dec
+                  order by dec desc nulls last) as bar;
+       ELSIF sortBy = 'essenceAsc' THEN
+        RETURN QUERY select id, name, author_id, path_id, power_id, modified, created, description, archetype, type
+          from ( select * from mythgard.search_decks_nosort(deckName, authorName, deckModified, card1,
+                  card2, card3, card4, card5, faction1, faction2, faction3, faction4, faction5,
+                  faction6, numFactions, archetypeFilter, typeFilter, pathName, powerName) as foo,
+                  mythgard.deck_essence_cost(foo.id) as dec
+                  order by dec asc nulls last) as bar;
+       ELSIF sortBy = 'ratingDesc' THEN
+        RETURN QUERY select deck.* from mythgard.search_decks_nosort(deckName, authorName, deckModified, card1,
+                  card2, card3, card4, card5, faction1, faction2, faction3, faction4, faction5,
+                  faction6, numFactions, archetypeFilter, typeFilter, pathName, powerName) as deck
+          LEFT JOIN
+          (SELECT count(*) as voteCount, deck_id from mythgard.deck_vote group by deck_id) as deckVotes
+          on deckVotes.deck_id = deck.id
+          where deck.id is not null
+          order by voteCount desc nulls last;
+       ELSIF sortBy = 'ratingAsc' THEN
+        RETURN QUERY select deck.* from mythgard.search_decks_nosort(deckName, authorName, deckModified, card1,
+                  card2, card3, card4, card5, faction1, faction2, faction3, faction4, faction5,
+                  faction6, numFactions, archetypeFilter, typeFilter, pathName, powerName) as deck
+          LEFT JOIN
+          (SELECT count(*) as voteCount, deck_id from mythgard.deck_vote group by deck_id) as deckVotes
+          on deckVotes.deck_id = deck.id
+          where deck.id is not null
+          order by voteCount asc nulls first;
+       ELSIF sortBy = 'nameAsc' THEN
+         RETURN QUERY select * from mythgard.search_decks_nosort(deckName, authorName, deckModified, card1,
+                  card2, card3, card4, card5, faction1, faction2, faction3, faction4, faction5,
+                  faction6, numFactions, archetypeFilter, typeFilter, pathName, powerName) order by lower(name) asc;
+       ELSIF sortBy = 'nameDesc' THEN
+         RETURN QUERY select * from mythgard.search_decks_nosort(deckName, authorName, deckModified, card1,
+                  card2, card3, card4, card5, faction1, faction2, faction3, faction4, faction5,
+                  faction6, numFactions, archetypeFilter, typeFilter, pathName, powerName) order by lower(name) desc;
+       ELSIF sortBy = 'dateDesc' THEN
+         RETURN QUERY select * from mythgard.search_decks_nosort(deckName, authorName, deckModified, card1,
+                  card2, card3, card4, card5, faction1, faction2, faction3, faction4, faction5,
+                  faction6, numFactions, archetypeFilter, typeFilter, pathName, powerName) order by created desc;
+       ELSIF sortBy = 'dateAsc' THEN
+         RETURN QUERY select * from mythgard.search_decks_nosort(deckName, authorName, deckModified, card1,
+                  card2, card3, card4, card5, faction1, faction2, faction3, faction4, faction5,
+                  faction6, numFactions, archetypeFilter, typeFilter, pathName, powerName) order by created asc;
+       ELSIF sortBy = 'hot' THEN
+         RETURN QUERY select * from mythgard.search_decks_nosort(deckName, authorName, deckModified, card1,
+                  card2, card3, card4, card5, faction1, faction2, faction3, faction4, faction5,
+                  faction6, numFactions, archetypeFilter, typeFilter, pathName, powerName) order by mythgard.deck_hotness(id) desc;
+       ELSE
+          RETURN QUERY select * from mythgard.search_decks_nosort(deckName, authorName, deckModified, card1,
+                  card2, card3, card4, card5, faction1, faction2, faction3, faction4, faction5,
+                  faction6, numFactions, archetypeFilter, typeFilter, pathName, powerName);
+       END IF;
+       RETURN;
+   END
+
+  $$ language plpgsql stable;

--- a/postgres/migrations/next-migration.sql
+++ b/postgres/migrations/next-migration.sql
@@ -27,7 +27,24 @@ CREATE OR REPLACE VIEW mythgard.deck_preview as
   ON mythgard.power.id = mythgard.deck.power_id
 ;
 
-drop function mythgard.search_decks_nosort;
+drop function if exists mythgard.search_decks_nosort(
+  deckName varchar(255),
+  authorName varchar(255),
+  deckModified date,
+  card1 integer,
+  card2 Integer,
+  card3 Integer,
+  card4 Integer,
+  card5 Integer,
+  faction1 integer,
+  faction2 integer,
+  faction3 integer,
+  faction4 integer,
+  faction5 integer,
+  faction6 integer,
+  numFactions integer,
+  archetypeFilter mythgard.deckArchetype[],
+  typeFilter mythgard.deckType[]);
 
 create or replace function mythgard.search_decks_nosort(
   deckName varchar(255),
@@ -120,7 +137,25 @@ create or replace function mythgard.search_decks_nosort(
     LIMIT 2000;
   $$ language sql stable;
 
-drop function mythgard.search_decks;
+drop function if exists mythgard.search_decks(
+  deckName varchar(255),
+  authorName varchar(255),
+  deckModified date,
+  card1 integer,
+  card2 Integer,
+  card3 Integer,
+  card4 Integer,
+  card5 Integer,
+  faction1 integer,
+  faction2 integer,
+  faction3 integer,
+  faction4 integer,
+  faction5 integer,
+  faction6 integer,
+  numFactions integer,
+  archetypeFilter mythgard.deckArchetype[],
+  typeFilter mythgard.deckType[],
+  sortBy text);
 
 create or replace function mythgard.search_decks(
   deckName varchar(255),

--- a/postgres/migrations/next-migration.sql
+++ b/postgres/migrations/next-migration.sql
@@ -1,0 +1,28 @@
+CREATE OR REPLACE VIEW mythgard.deck_preview as
+  SELECT deck.id as deck_id,
+         deck.name as deck_name,
+         deck.created as deck_created,
+         mythgard.deck_factions(deck.id) as factions,
+         mythgard.deck_essence_cost(deck.id)::int as essence_cost,
+         mythgard.deck_votes(deck.id)::int as votes,
+         deck.archetype as deck_archetype,
+         deck.type as deck_type,
+         deck.modified as deck_modified,
+         account.id as account_id,
+         account.username as username,
+         account.account_type as account_type,
+         account.profile_icon_id as profile_icon_id,
+         mythgard.deck_hotness(deck.id)::int as hotness,
+         deck_views.views::int as views,
+         path.name as path_name,
+         power.name as power_name
+  FROM mythgard.deck
+  LEFT JOIN mythgard.account
+  ON mythgard.account.id = mythgard.deck.author_id
+  LEFT JOIN mythgard.deck_views
+  ON mythgard.deck_views.deck_id = mythgard.deck.id
+  LEFT JOIN mythgard.path
+  ON mythgard.path.id = mythgard.deck.path_id
+  LEFT JOIN mythgard.power
+  ON mythgard.power.id = mythgard.deck.power_id
+;


### PR DESCRIPTION
The filters look like this (like our usual):
![image](https://user-images.githubusercontent.com/4063797/89114229-041d8a00-d448-11ea-9f35-cd90fe107871.png)

The paths and powers themselves can't quite be seen since we don't have images for our fake ones, but if you import the prod database and run the migrations, it looks like this
![image](https://user-images.githubusercontent.com/4063797/89114324-24017d80-d449-11ea-86e3-644e1c2dcb46.png)
