### PR TITLE
Add the ability to filter by 0 cost, 0 attack or 0 defense

### DIFF
--- a/next/components/numeric-filter-group.js
+++ b/next/components/numeric-filter-group.js
@@ -5,6 +5,11 @@ import { ThemeContext } from './theme-context';
 const cdn = process.env.MG_CDN;
 const images = [
   {
+    key: 0,
+    label: '0',
+    link: `${cdn}/filters/Filter-Icons_0000s_0001s_0006_0.png`
+  },
+  {
     key: 1,
     label: '1',
     link: `${cdn}/filters/Filter-Icons_0000s_0001s_0005_1.png`
@@ -52,8 +57,8 @@ export default function NumericFilterGroup({ cyName, selected, onChange }) {
       <style jsx>{`
         img {
           cursor: pointer;
-          height: 30px;
-          margin-right: 20px;
+          height: 28px;
+          margin-right: 15px;
           opacity: 0.6;
         }
 

--- a/postgres/init.sql
+++ b/postgres/init.sql
@@ -72,6 +72,8 @@ INSERT INTO mythgard.card (name, rules, subtype, mana, gem, rarity, supertype)
   VALUES ('Ghul', 'rock', 'Earth Enchantment', '1', 'R', 'RARE', '{MINION}');
 INSERT INTO mythgard.card (name, rules, subtype, mana, gem, rarity, supertype)
   VALUES ('X Cost', 'lifelink', 'vampire', '-1', 'G', 'MYTHIC', '{MINION, ENCHANTMENT}');
+INSERT INTO mythgard.card (name, rules, subtype, atk, def, mana, gem, rarity, supertype)
+  VALUES ('0 Cost 0 attack 0 defense', 'lifelink', 'vampire', '0', '0', '0', 'G', 'MYTHIC', '{MINION, ENCHANTMENT}');
 INSERT INTO mythgard.card (name, rules, subtype, mana, gem, rarity, supertype, cardset)
   VALUES ('New Set', 'example of the new set', 'vampire', '2', 'PP', 'MYTHIC', '{MINION, ENCHANTMENT}', 'Rings of Immortality');
 INSERT INTO mythgard.card (name, rules, subtype, mana, gem, rarity, supertype, spawnonly)


### PR DESCRIPTION
Small change to add 0 filters to the cards page. There are no 0 defense\health cards for now but... ya never know. 

![image](https://user-images.githubusercontent.com/4063797/111093641-b0534300-84f6-11eb-9f97-210caf650b12.png)

The icon doesn't look great so I won't merge it until we have a better icon in aws though